### PR TITLE
feat: Support slot props and default content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
       run: npm run lint
     - name: Test
       run: npm run test
+    - name: Test Project
+      run: npm run test-project

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-const config = require('./tools/babel/babel.config');
-
-module.exports = config;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
-const { createConfig } = require('./tools');
-
-module.exports = createConfig('test');
+module.exports = {
+  projects: [
+    'tools',
+    'runtime',
+    'shell',
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "nodemon": "^3.1.4"
       },
       "peerDependencies": {
-        "@openedx/paragon": "^22.17.0",
+        "@openedx/paragon": "^22.20.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^8.1.3",
@@ -3575,9 +3575,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "22.20.0",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.20.0.tgz",
-      "integrity": "sha512-AnqCnIxVe5rbaqU2DzrBbWO+fB0f0hFHxXZvl4xiEQgZqziFvRiha4NBY16iVm+s9lYgmz8xjZ+PSunxYGT2JA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.20.1.tgz",
+      "integrity": "sha512-0P+VResXaBdAauMdChxg1x4cnBdxYK7UZoXAtJn8zSnLR5sxMvlhfKdktW1Si7K5cVkkeCoDF41ZjOJ0aYILKQ==",
       "license": "Apache-2.0",
       "peer": true,
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "nodemon": "^3.1.4"
   },
   "peerDependencies": {
-    "@openedx/paragon": "^22.17.0",
+    "@openedx/paragon": "^22.20.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^8.1.3",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,9 @@
     "docs:watch": "nodemon -w runtime -w docs/template -w README.md -e js,jsx,ts,tsx --exec npm run docs",
     "lint": "eslint .; npm run lint:tools; npm --prefix ./test-project run lint",
     "lint:tools": "cd ./tools && eslint . && cd ..",
-    "refresh:test-project": "npm run build && npm pack && cd test-project && npm i --audit=false --fund=false ../openedx-frontend-base-1.0.0.tgz && cd ../",
-    "test": "npm run test:tools && npm run test:app && npm run test:runtime && npm run test:shell",
-    "test:app": "npm --prefix ./test-project i; npm --prefix ./test-project run build",
-    "test:tools": "jest tools --config tools/jest.config.js",
-    "test:runtime": "jest runtime --config runtime/jest.config.js",
-    "test:shell": "jest shell --config shell/jest.config.js --passWithNoTests --coverage"
+    "test": "jest",
+    "test-project": "npm --prefix ./test-project i; npm --prefix ./test-project run build",
+    "test-project:refresh": "npm run build && npm pack && cd test-project && npm i --audit=false --fund=false ../openedx-frontend-base-1.0.0.tgz && cd ../"
   },
   "repository": {
     "type": "git",

--- a/runtime/babel.config.js
+++ b/runtime/babel.config.js
@@ -1,0 +1,3 @@
+const config = require('../tools/babel/babel.config');
+
+module.exports = config;

--- a/runtime/jest.config.js
+++ b/runtime/jest.config.js
@@ -1,35 +1,31 @@
 module.exports = {
   setupFilesAfterEnv: [
-    '<rootDir>/runtime/setupTest.js',
+    '<rootDir>/setupTest.js',
   ],
   moduleNameMapper: {
-    '\\.svg$': '<rootDir>/runtime/__mocks__/svg.js',
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/runtime/__mocks__/file.js',
+    '\\.svg$': '<rootDir>/__mocks__/svg.js',
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir/__mocks__/file.js',
     '\\.(css|scss)$': require.resolve('identity-obj-proxy'),
-    'site.config': '<rootDir>/runtime/test.site.config.tsx',
+    'site.config': '<rootDir>/test.site.config.tsx',
   },
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
-  rootDir: process.cwd(),
   collectCoverageFrom: [
-    'runtime/**/*.{js,jsx,ts,tsx}',
+    '<rootDir>/**/*.{js,jsx,ts,tsx}',
   ],
   coveragePathIgnorePatterns: [
-    '/node_modules/',
-    'setupTest.js',
+    '<rootDir>/setupTest.js',
   ],
   transformIgnorePatterns: [
     '/node_modules/(?!(@openedx|@edx)/)',
   ],
   modulePathIgnorePatterns: [
-    '<rootDir>/dist',
-    '<rootDir>/shell',
-    '<rootDir>/tools',
+    '/dist/',
   ],
   testPathIgnorePatterns: [
     '/node_modules/',
-    '<rootDir>/dist/',
+    '/dist/',
   ],
 };

--- a/runtime/react/AuthenticatedPageRoute.jsx
+++ b/runtime/react/AuthenticatedPageRoute.jsx
@@ -21,7 +21,7 @@ import { useAuthenticatedUser } from './hooks';
  * @param {string} props.redirectUrl The URL anonymous users should be redirected to, rather than
  * viewing the route's contents.
  */
-export default function AuthenticatedPageRoute({ redirectUrl, children }) {
+export default function AuthenticatedPageRoute({ redirectUrl = null, children }) {
   const authenticatedUser = useAuthenticatedUser();
   if (authenticatedUser === null) {
     const destination = redirectUrl || getLoginRedirectUrl(global.location.href);
@@ -40,8 +40,4 @@ export default function AuthenticatedPageRoute({ redirectUrl, children }) {
 AuthenticatedPageRoute.propTypes = {
   redirectUrl: PropTypes.string,
   children: PropTypes.node.isRequired,
-};
-
-AuthenticatedPageRoute.defaultProps = {
-  redirectUrl: null,
 };

--- a/runtime/react/ErrorPage.jsx
+++ b/runtime/react/ErrorPage.jsx
@@ -21,7 +21,7 @@ import {
  * @extends {Component}
  */
 function ErrorPage({
-  message,
+  message = null,
 }) {
   const [locale, setLocale] = useState(getLocale());
 
@@ -67,10 +67,6 @@ function ErrorPage({
 
 ErrorPage.propTypes = {
   message: PropTypes.string,
-};
-
-ErrorPage.defaultProps = {
-  message: null,
 };
 
 export default ErrorPage;

--- a/runtime/slots/Slot.tsx
+++ b/runtime/slots/Slot.tsx
@@ -5,13 +5,16 @@ import SlotContext from './SlotContext';
 
 interface SlotProps {
   id: string,
+  children?: ReactNode,
   layout?: ComponentType | ReactNode,
+  [key: string]: unknown,
 }
 
-export default function Slot({ id, layout = DefaultSlotLayout }: SlotProps) {
+export default function Slot({ id, children, layout = DefaultSlotLayout, ...props }: SlotProps) {
   let layoutElement: ComponentType | ReactNode = layout;
 
   const overrideLayout = useLayoutForSlotId(id);
+
   // Weed out any ReactNode types that aren't actually JSX.
   if (overrideLayout && overrideLayout !== null && overrideLayout !== undefined && typeof overrideLayout !== 'boolean') {
     layoutElement = overrideLayout;
@@ -22,7 +25,7 @@ export default function Slot({ id, layout = DefaultSlotLayout }: SlotProps) {
   }
 
   return (
-    <SlotContext.Provider value={{ id }}>
+    <SlotContext.Provider value={{ id, children, ...props }}>
       {layoutElement}
     </SlotContext.Provider>
   );

--- a/runtime/slots/SlotContext.tsx
+++ b/runtime/slots/SlotContext.tsx
@@ -1,7 +1,8 @@
-import { createContext } from 'react';
+import { createContext, ReactNode } from 'react';
 
-const SlotContext = createContext<{ id: string }>({
+const SlotContext = createContext<{ id: string, children?: ReactNode, [key: string]: unknown }>({
   id: '',
+  children: null,
 });
 
 export default SlotContext;

--- a/runtime/slots/hooks.ts
+++ b/runtime/slots/hooks.ts
@@ -3,6 +3,7 @@ import { useContext, useEffect, useState } from 'react';
 import { APPS_CHANGED } from '../constants';
 import { useAppEvent } from '../react';
 
+import { WidgetOperation, WidgetOperationTypes } from './widget';
 import { SlotOperation } from './types';
 import { getSlotOperations } from './utils';
 import SlotContext from './SlotContext';
@@ -13,16 +14,27 @@ import SlotContext from './SlotContext';
  * config as it changes.
  */
 export function useSlotOperations(id: string) {
-  const [operations, setOperations] = useState<SlotOperation[]>(getSlotOperations(id));
+  const { children } = useSlotContext();
+  let defaultOperation: WidgetOperation | undefined = undefined;
+  if (children) {
+    defaultOperation = {
+      slotId: id,
+      id: `defaultContent`,
+      op: WidgetOperationTypes.APPEND,
+      element: children
+    };
+  }
+
+  const [operations, setOperations] = useState<SlotOperation[]>(getSlotOperations(id, defaultOperation));
   useAppEvent(APPS_CHANGED, () => {
-    const ops = getSlotOperations(id);
+    const ops = getSlotOperations(id, defaultOperation);
     setOperations(ops);
   });
 
   useEffect(() => {
-    const ops = getSlotOperations(id);
+    const ops = getSlotOperations(id, defaultOperation);
     setOperations(ops);
-  }, [id]);
+  }, [id, defaultOperation]);
   return operations;
 }
 

--- a/runtime/slots/layout/hooks.ts
+++ b/runtime/slots/layout/hooks.ts
@@ -54,7 +54,7 @@ export function useLayoutOptionsForId(id: string) {
       }
     }
     return nextOptions;
-  }, [operations, id]);
+  }, [operations]);
 
   const [options, setOptions] = useState<Record<string, unknown>>(findOptions());
 

--- a/runtime/slots/utils.ts
+++ b/runtime/slots/utils.ts
@@ -2,9 +2,14 @@ import { getAuthenticatedUser } from '../auth';
 import { getActiveRoles, getConfig } from '../config';
 import { SlotOperation } from './types';
 
-export function getSlotOperations(id: string) {
+export function getSlotOperations(id: string, defaultOperation?: SlotOperation) {
   const { apps } = getConfig();
   const ops: SlotOperation[] = [];
+
+  if (defaultOperation) {
+    ops.push(defaultOperation);
+  }
+
   apps.forEach((app) => {
     if (Array.isArray(app.slots)) {
       app.slots.forEach((operation) => {
@@ -14,6 +19,7 @@ export function getSlotOperations(id: string) {
       });
     }
   });
+
   return ops;
 }
 

--- a/runtime/slots/widget/hooks.ts
+++ b/runtime/slots/widget/hooks.ts
@@ -6,16 +6,17 @@ import { createWidgets, isWidgetAbsoluteOperation, isWidgetOperation, isWidgetOp
 import WidgetContext from './WidgetContext';
 
 export function useWidgets() {
-  const { id } = useSlotContext();
-  return useWidgetsForId(id);
+  const { id, ...props } = useSlotContext();
+  delete props.children;
+  return useWidgetsForId(id, props);
 }
 
-export function useWidgetsForId(id: string) {
+export function useWidgetsForId(id: string, componentProps?: Record<string, unknown>) {
   const operations = useSortedWidgetOperations(id);
-  return createWidgets(operations);
+  return createWidgets(operations, componentProps);
 }
 
-export function useWidgetOperations(id) {
+export function useWidgetOperations(id: string) {
   const operations = useSlotOperations(id);
 
   const filterOperations = useCallback(() => {
@@ -33,7 +34,7 @@ export function useWidgetOperations(id) {
   return widgetOperations;
 }
 
-export function useSortedWidgetOperations(id) {
+export function useSortedWidgetOperations(id: string) {
   const operations = useWidgetOperations(id);
 
   // This function sorts widget operations in an order that guarantees that any 'related' widgets

--- a/runtime/slots/widget/utils.tsx
+++ b/runtime/slots/widget/utils.tsx
@@ -86,12 +86,12 @@ function hasWidgetIdentityRoleProps(operation: WidgetOperation): operation is (W
 /**
  * An 'identified' widget just means a data structure with an ID and a ReactNode.
  */
-function createIdentifiedWidget(operation: WidgetRendererOperation) {
+function createIdentifiedWidget(operation: WidgetRendererOperation, componentProps?: Record<string, unknown>) {
   let widget: ReactNode = null;
   const { id } = operation;
   if (hasWidgetComponentProps(operation)) {
     widget = (
-      <operation.component />
+      <operation.component {...componentProps} />
     );
   } else if (hasWidgetElementProps(operation)) {
     widget = operation.element;
@@ -120,34 +120,34 @@ function findRelatedWidgetIndex(id: string, widgets: IdentifiedWidget[]) {
   return null;
 }
 
-function appendWidget(operation: WidgetAppendOperation, widgets: IdentifiedWidget[]) {
-  const widget = createIdentifiedWidget(operation);
+function appendWidget(operation: WidgetAppendOperation, widgets: IdentifiedWidget[], componentProps?: Record<string, unknown>) {
+  const widget = createIdentifiedWidget(operation, componentProps);
   widgets.push(widget);
 }
 
-function prependWidget(operation: WidgetPrependOperation, widgets: IdentifiedWidget[]) {
-  const widget = createIdentifiedWidget(operation);
+function prependWidget(operation: WidgetPrependOperation, widgets: IdentifiedWidget[], componentProps?: Record<string, unknown>) {
+  const widget = createIdentifiedWidget(operation, componentProps);
   widgets.unshift(widget);
 }
 
-function insertAfterWidget(operation: WidgetInsertAfterOperation, widgets: IdentifiedWidget[]) {
-  const widget = createIdentifiedWidget(operation);
+function insertAfterWidget(operation: WidgetInsertAfterOperation, widgets: IdentifiedWidget[], componentProps?: Record<string, unknown>) {
+  const widget = createIdentifiedWidget(operation, componentProps);
   const relatedIndex = findRelatedWidgetIndex(operation.relatedId, widgets);
   if (relatedIndex !== null) {
     widgets.splice(relatedIndex + 1, 0, widget);
   }
 }
 
-function insertBeforeWidget(operation: WidgetInsertBeforeOperation, widgets: IdentifiedWidget[]) {
-  const widget = createIdentifiedWidget(operation);
+function insertBeforeWidget(operation: WidgetInsertBeforeOperation, widgets: IdentifiedWidget[], componentProps?: Record<string, unknown>) {
+  const widget = createIdentifiedWidget(operation, componentProps);
   const relatedIndex = findRelatedWidgetIndex(operation.relatedId, widgets);
   if (relatedIndex !== null) {
     widgets.splice(relatedIndex, 0, widget);
   }
 }
 
-function replaceWidget(operation: WidgetReplaceOperation, widgets: IdentifiedWidget[]) {
-  const widget = createIdentifiedWidget(operation);
+function replaceWidget(operation: WidgetReplaceOperation, widgets: IdentifiedWidget[], componentProps?: Record<string, unknown>) {
+  const widget = createIdentifiedWidget(operation, componentProps);
   const relatedIndex = findRelatedWidgetIndex(operation.relatedId, widgets);
   if (relatedIndex !== null) {
     widgets.splice(relatedIndex, 1, widget);
@@ -161,21 +161,21 @@ function removeWidget(operation: WidgetRemoveOperation, widgets: IdentifiedWidge
   }
 }
 
-export function createWidgets(operations: WidgetOperation[]) {
+export function createWidgets(operations: WidgetOperation[], componentProps?: Record<string, unknown>) {
   const identifiedWidgets: IdentifiedWidget[] = [];
 
   for (const operation of operations) {
     if (isSlotOperationConditionSatisfied(operation)) {
       if (isWidgetAppendOperation(operation)) {
-        appendWidget(operation, identifiedWidgets);
+        appendWidget(operation, identifiedWidgets, componentProps);
       } else if (isWidgetPrependOperation(operation)) {
-        prependWidget(operation, identifiedWidgets);
+        prependWidget(operation, identifiedWidgets, componentProps);
       } else if (isWidgetInsertAfterOperation(operation)) {
-        insertAfterWidget(operation, identifiedWidgets);
+        insertAfterWidget(operation, identifiedWidgets, componentProps);
       } else if (isWidgetInsertBeforeOperation(operation)) {
-        insertBeforeWidget(operation, identifiedWidgets);
+        insertBeforeWidget(operation, identifiedWidgets, componentProps);
       } else if (isWidgetReplaceOperation(operation)) {
-        replaceWidget(operation, identifiedWidgets);
+        replaceWidget(operation, identifiedWidgets, componentProps);
       } else if (isWidgetRemoveOperation(operation)) {
         removeWidget(operation, identifiedWidgets);
       }

--- a/shell/babel.config.js
+++ b/shell/babel.config.js
@@ -1,0 +1,3 @@
+const config = require('../tools/babel/babel.config');
+
+module.exports = config;

--- a/shell/dev-project/slot-showcase/SlotShowcasePage.tsx
+++ b/shell/dev-project/slot-showcase/SlotShowcasePage.tsx
@@ -17,6 +17,12 @@ export default function SlotShowcasePage() {
       <p>This slot has no opinionated layout, it just renders its children.</p>
       <Slot id="org.openedx.frontend.slot.devProject.slotShowcaseSimple" />
 
+      <h3>Simple slot with default content and props</h3>
+      <p>This slot has default content, and it exposes a slot prop to widgets.</p>
+      <Slot id="org.openedx.frontend.slot.devProject.slotShowcaseSimpleWithDefaultContent" aSlotProp="hello!">
+        <div>Look, I&apos;m default content!</div>
+      </Slot>
+
       <h2>UI Layout Operations</h2>
 
       <h3>Slot with custom layout</h3>

--- a/shell/dev-project/slot-showcase/index.tsx
+++ b/shell/dev-project/slot-showcase/index.tsx
@@ -1,4 +1,4 @@
-import { LayoutOperationTypes, WidgetOperationTypes } from '../../../runtime';
+import { LayoutOperationTypes, WidgetOperationTypes, useSlotContext } from '../../../runtime';
 import { App } from '../../../types';
 import HorizontalSlotLayout from './HorizontalSlotLayout';
 import SlotShowcasePage from './SlotShowcasePage';
@@ -23,6 +23,20 @@ function Child({ title, op }: { title: string, op?: string }) {
         <span>{' '}(<code>{op}</code>)</span>
       )}
     </div>
+  );
+}
+
+function TakesProps({ aSlotProp }: { aSlotProp: string }) {
+  return (
+    <div>And this is a slot prop that was passed down via props: <code>{aSlotProp}</code></div>
+  );
+}
+
+function TakesPropsViaContext() {
+  const slotContext = useSlotContext();
+  const aSlotProp = typeof slotContext.aSlotProp === 'string' ? slotContext.aSlotProp : 'foo';
+  return (
+    <div>And this is the same prop, but accessed via slot context: <code>{aSlotProp}</code></div>
   );
 }
 
@@ -54,6 +68,18 @@ const config: App = {
       id: 'slot-showcase.simple.child3',
       op: WidgetOperationTypes.APPEND,
       element: (<Child title="Child Three" />)
+    },
+    {
+      slotId: 'org.openedx.frontend.slot.devProject.slotShowcaseSimpleWithDefaultContent',
+      id: 'slot-showcase.simple.child4',
+      op: WidgetOperationTypes.APPEND,
+      component: TakesProps
+    },
+    {
+      slotId: 'org.openedx.frontend.slot.devProject.slotShowcaseSimpleWithDefaultContent',
+      id: 'slot-showcase.simple.child4',
+      op: WidgetOperationTypes.APPEND,
+      component: TakesPropsViaContext
     },
 
     // Custom Layout
@@ -272,8 +298,7 @@ const config: App = {
       relatedId: 'slot-showcase.widgetOptions.child2',
       op: WidgetOperationTypes.OPTIONS,
       options: {
-        title: (<Title title="Bar" op="WidgetOperationTypes.OPTIONS" />
-        ),
+        title: (<Title title="Bar" op="WidgetOperationTypes.OPTIONS" />),
       }
     },
   ]

--- a/shell/jest.config.js
+++ b/shell/jest.config.js
@@ -1,20 +1,19 @@
 module.exports = {
   setupFilesAfterEnv: [
-    '<rootDir>/shell/setupTest.js',
+    './setupTest.js',
   ],
   moduleNameMapper: {
-    '\\.svg$': '<rootDir>/shell/__mocks__/svg.js',
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/shell/__mocks__/file.js',
+    '\\.svg$': '<rootDir>/__mocks__/svg.js',
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/file.js',
     '\\.(css|scss)$': require.resolve('identity-obj-proxy'),
-    'site.config': '<rootDir>/shell/test.site.config.tsx',
+    'site.config': '<rootDir>/test.site.config.tsx',
   },
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
-  rootDir: process.cwd(),
   collectCoverageFrom: [
-    'shell/**/*.{js,jsx,ts,tsx}',
+    '<rootDir>/**/*.{js,jsx,ts,tsx}',
   ],
   coveragePathIgnorePatterns: [
     '/node_modules/',
@@ -23,13 +22,8 @@ module.exports = {
   transformIgnorePatterns: [
     '/node_modules/(?!(@openedx|@edx)/)',
   ],
-  modulePathIgnorePatterns: [
-    '<rootDir>/dist',
-    '<rootDir>/runtime',
-    '<rootDir>/tools',
-  ],
   testPathIgnorePatterns: [
     '/node_modules/',
-    '<rootDir>/dist/',
+    '/dist/',
   ],
 };

--- a/test-project/package-lock.json
+++ b/test-project/package-lock.json
@@ -16,7 +16,7 @@
       },
       "peerDependencies": {
         "@openedx/frontend-base": "file:../openedx-frontend-base-1.0.0.tgz",
-        "@openedx/paragon": "^22.17.0",
+        "@openedx/paragon": "^22.20.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^8.1.3",
@@ -3635,7 +3635,7 @@
     "node_modules/@openedx/frontend-base": {
       "version": "1.0.0",
       "resolved": "file:../openedx-frontend-base-1.0.0.tgz",
-      "integrity": "sha512-1YqudVgQTOUpACaC16F7bJTfEKw+NA8NpaERyD5RuGUvKqkbOq7ki3J8ckEyvF2ceCCFNmBjAivjVj5LuEBtgA==",
+      "integrity": "sha512-Tle/ayvF/e2IbvXloDcKheBbDQtBt8ZYjWUMAs0LsJs55hgyJzZ80/LdYFKkwCcLvzVRIdzqO59TL4xv6hGOvQ==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -3728,7 +3728,7 @@
         "transifex-utils.js": "tools/dist/cli/scripts/transifex-utils.js"
       },
       "peerDependencies": {
-        "@openedx/paragon": "^22.17.0",
+        "@openedx/paragon": "^22.20.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^8.1.3",
@@ -3738,9 +3738,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "22.20.0",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.20.0.tgz",
-      "integrity": "sha512-AnqCnIxVe5rbaqU2DzrBbWO+fB0f0hFHxXZvl4xiEQgZqziFvRiha4NBY16iVm+s9lYgmz8xjZ+PSunxYGT2JA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.20.1.tgz",
+      "integrity": "sha512-0P+VResXaBdAauMdChxg1x4cnBdxYK7UZoXAtJn8zSnLR5sxMvlhfKdktW1Si7K5cVkkeCoDF41ZjOJ0aYILKQ==",
       "license": "Apache-2.0",
       "peer": true,
       "workspaces": [

--- a/test-project/package.json
+++ b/test-project/package.json
@@ -14,7 +14,7 @@
   "license": "AGPL-3.0",
   "peerDependencies": {
     "@openedx/frontend-base": "file:../openedx-frontend-base-1.0.0.tgz",
-    "@openedx/paragon": "^22.17.0",
+    "@openedx/paragon": "^22.20.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^8.1.3",

--- a/test-project/src/example-page/Image.tsx
+++ b/test-project/src/example-page/Image.tsx
@@ -8,9 +8,4 @@ interface ImageProps {
 
 const Image = ({ alt, ...rest }: ImageProps) => <img alt={alt} {...rest} />;
 
-const defaultProps = {
-  alt: undefined,
-  style: undefined,
-};
-Image.defaultProps = defaultProps;
 export default Image;

--- a/tools/babel.config.js
+++ b/tools/babel.config.js
@@ -1,0 +1,3 @@
+const config = require('./babel/babel.config');
+
+module.exports = config;

--- a/tools/jest.config.js
+++ b/tools/jest.config.js
@@ -3,25 +3,17 @@ module.exports = {
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
-  rootDir: process.cwd(),
   collectCoverageFrom: [
     'cli/**/*.{js,jsx,ts,tsx}',
-  ],
-  coveragePathIgnorePatterns: [
-    '/node_modules/',
   ],
   transformIgnorePatterns: [
     '/node_modules/(?!(@openedx|@edx)/)',
   ],
   modulePathIgnorePatterns: [
-    '<rootDir>/dist',
-    '<rootDir>/runtime',
-    '<rootDir>/shell',
-    '<rootDir>/tools/dist',
+    '/dist/',
   ],
   testPathIgnorePatterns: [
     '/node_modules/',
-    '<rootDir>/dist',
-    '<rootDir>/tools/dist',
+    '/dist/',
   ],
 };

--- a/tools/jest/jest.config.js
+++ b/tools/jest/jest.config.js
@@ -20,10 +20,10 @@ module.exports = {
     '/node_modules/(?!(@openedx|@edx)/)',
   ],
   modulePathIgnorePatterns: [
-    '<rootDir>/dist/',
+    '/dist/',
   ],
   testPathIgnorePatterns: [
     '/node_modules/',
-    '<rootDir>/dist/',
+    '/dist/',
   ],
 };


### PR DESCRIPTION
Implement the essential features of frontend-plugin-framework:

* Passing arbitrary props down to widgets
* Defining slot children, a.k.a. default content

In addition, slot props also populate the slot's context, allowing complex widgets to avoid prop drilling, if necessary.

The following commits are included for expediency:

- **test: refactor jest configuration**
- **fix: defaultProps deprecation warnings**
- **chore: upgrade the minimum version of Paragon**