### PR TITLE
fix!: [DEPR] Cleanup New Relic Source Map Webpack Plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@babel/preset-env": "^7.24.8",
         "@babel/preset-react": "^7.26.3",
         "@babel/preset-typescript": "^7.24.7",
-        "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
         "@eslint/compat": "^1.2.1",
         "@eslint/js": "^9.13.0",
         "@formatjs/cli": "^6.0.3",
@@ -2027,15 +2026,6 @@
       "integrity": "sha512-d2ggwi5j4DOBJOwhWZxBWQSDR0DhT4ke/1PbzRauICdFkuOyax+PsFjK8GUh443K2OaQpy9PGfiCzZ1Yg37AUA==",
       "dev": true,
       "license": "AGPL-3.0"
-    },
-    "node_modules/@edx/new-relic-source-map-webpack-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/new-relic-source-map-webpack-plugin/-/new-relic-source-map-webpack-plugin-2.1.0.tgz",
-      "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
-      "license": "AGPL-3.0",
-      "dependencies": {
-        "@newrelic/publish-sourcemap": "^5.0.1"
-      }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@babel/preset-env": "^7.24.8",
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.24.7",
-    "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
     "@eslint/compat": "^1.2.1",
     "@eslint/js": "^9.13.0",
     "@formatjs/cli": "^6.0.3",

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -2048,16 +2048,6 @@
       "dev": true,
       "license": "AGPL-3.0"
     },
-    "node_modules/@edx/new-relic-source-map-webpack-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/new-relic-source-map-webpack-plugin/-/new-relic-source-map-webpack-plugin-2.1.0.tgz",
-      "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
-      "license": "AGPL-3.0",
-      "peer": true,
-      "dependencies": {
-        "@newrelic/publish-sourcemap": "^5.0.1"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
@@ -3643,7 +3633,6 @@
         "@babel/preset-env": "^7.24.8",
         "@babel/preset-react": "^7.26.3",
         "@babel/preset-typescript": "^7.24.7",
-        "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
         "@eslint/compat": "^1.2.1",
         "@eslint/js": "^9.13.0",
         "@formatjs/cli": "^6.0.3",

--- a/tools/webpack/modules.d.ts
+++ b/tools/webpack/modules.d.ts
@@ -1,6 +1,5 @@
 // This file needs to exist to declare modules for dependencies that don't publish their types.
 
 declare module 'postcss-custom-media';
-declare module '@edx/new-relic-source-map-webpack-plugin';
 declare module 'mini-css-extract-plugin';
 declare module 'webpack-bundle-analyzer';


### PR DESCRIPTION
Removed new-relic-source-map-webpack-plugin imports/requires from all webpack configuration files. Cleaned up plugin configurations and related code. Removed any associated New Relic source map upload functionality