### PR TITLE
feat: a sane basename

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Then move the files out of the way (move src to some other sub-dir, mostly) to m
   - csrfTokenApiPath: '/csrf/api/v1/token',
   - languagePreferenceCookieName: 'openedx-language-preference',
   - userInfoCookieName: 'edx-user-info',
-  - publicPath: '/',
   - environment: 'production',
-- the `basename` and `history` exports have been replaced by function getters: `getBasename` and `getHistory`.  This is because it may not be possible to determine the values of the original constants at code initialization time, since our config may arrive asynchronously.  This ensures that anyone trying to get these values gets a current value.
+- the `basename` and export has been replaced by: `getBasename`.  This is because it may not be possible to determine the values of the original constants at code initialization time, since our config may arrive asynchronously.  This ensures that anyone trying to get these values gets a current value.
+- the `history` export no longer exists.  Consumers should be using react-router 6's `useNavigate()` API instead.
 - When using MockAuthService, set the authenticated user by calling setAuthenticatedUser after instantiating the service.  It's not okay for us to add arbitrary config values to the site config.
 - `REFRESH_ACCESS_TOKEN_ENDPOINT` has been replaced with `refreshAccessTokenApiPath`.  It is now a path that defaults to '/login_refresh'.  The Auth service assumes it is an endpoint on the LMS, and joins the path with `lmsBaseUrl`.  This change creates more parity with other paths such as `csrfTokenApiPath`.
 

--- a/docs/how_tos/migrate-frontend-app.md
+++ b/docs/how_tos/migrate-frontend-app.md
@@ -499,6 +499,9 @@ Optional config
 
 Other configuration is now optional, and many values have been given sensible defaults.  But these configuration variables are also available (as of this writing):
 
+- environment: EnvironmentTypes
+- basename: string
+- mfeConfigApiUrl: string | null
 - accessTokenCookieName: string
 - languagePreferenceCookieName: string
 - userInfoCookieName: string
@@ -506,9 +509,6 @@ Other configuration is now optional, and many values have been given sensible de
 - refreshAccessTokenApiPath: string
 - ignoredErrorRegex: RegExp | null
 - segmentKey: string | null
-- environment: EnvironmentTypes
-- mfeConfigApiUrl: string | null
-- publicPath: string
 
 URL Config changes
 ------------------
@@ -573,7 +573,7 @@ Once you've verified your test suite still works, you should delete the `.env.te
 A sample `site.config.test.tsx` file:
 
 ```
-import { SiteConfig } from '@openedx/frontend-base';
+import { EnvironmentTypes, SiteConfig } from '@openedx/frontend-base';
 
 const siteConfig: SiteConfig = {
   siteId: 'test',
@@ -582,7 +582,7 @@ const siteConfig: SiteConfig = {
   lmsBaseUrl: 'http://localhost:18000',
   loginUrl: 'http://localhost:18000/login',
   logoutUrl: 'http://localhost:18000/logout',
-  environment: 'dev',
+  environment: EnvironmentTypes.TEST,
   apps: [{
     appId: 'test-app',
     routes: [{
@@ -599,10 +599,9 @@ const siteConfig: SiteConfig = {
   csrfTokenApiPath: '/csrf/api/v1/token',
   languagePreferenceCookieName: 'openedx-language-preference',
   refreshAccessTokenApiPath: '/login_refresh',
-  segmentKey: '',
   userInfoCookieName: 'edx-user-info',
   ignoredErrorRegex: null,
-  publicPath: '/',
+  segmentKey: '',
 };
 
 export default siteConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "glob": "^7.2.3",
         "globals": "^15.11.0",
         "gradient-string": "^2.0.2",
-        "history": "^4.10.1",
         "html-webpack-plugin": "5.6.0",
         "identity-obj-proxy": "3.0.0",
         "image-minimizer-webpack-plugin": "3.8.3",
@@ -82,7 +81,7 @@
         "ts-loader": "^9.5.1",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.11.0",
-        "universal-cookie": "^4.0.4",
+        "universal-cookie": "^8.0.1",
         "url-loader": "^4.1.1",
         "uuid": "^11.0.2",
         "webpack": "^5.97.1",
@@ -117,7 +116,7 @@
         "nodemon": "^3.1.4"
       },
       "peerDependencies": {
-        "@openedx/paragon": "^22.20.1",
+        "@openedx/paragon": "^22.20.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^8.1.3",
@@ -3575,9 +3574,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.20.1.tgz",
-      "integrity": "sha512-0P+VResXaBdAauMdChxg1x4cnBdxYK7UZoXAtJn8zSnLR5sxMvlhfKdktW1Si7K5cVkkeCoDF41ZjOJ0aYILKQ==",
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.20.2.tgz",
+      "integrity": "sha512-4dGRGA/tz5uYebGJn0iLCcGWlvkleCq8WRNtVNWIf1jqzwea2fiVO8qxLNaFvIhpdR/jkzFjgdgY3ftj0rqOgQ==",
       "license": "Apache-2.0",
       "peer": true,
       "workspaces": [
@@ -4095,12 +4094,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
-      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -9462,20 +9455,6 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -15675,12 +15654,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "license": "MIT"
-    },
     "node_modules/resolve-url-loader": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
@@ -17624,18 +17597,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "license": "MIT"
-    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -18079,22 +18040,21 @@
       }
     },
     "node_modules/universal-cookie": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
-      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-8.0.1.tgz",
+      "integrity": "sha512-B6ks9FLLnP1UbPPcveOidfvB9pHjP+wekP2uRYB9YDfKVpvcjKgy1W5Zj+cEXJ9KTPnqOKGfVDQBmn8/YCQfRg==",
       "license": "MIT",
       "dependencies": {
-        "@types/cookie": "^0.3.3",
-        "cookie": "^0.4.0"
+        "cookie": "^1.0.2"
       }
     },
     "node_modules/universal-cookie/node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
       }
     },
     "node_modules/universalify": {
@@ -18309,12 +18269,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "license": "MIT"
     },
     "node_modules/varint": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "glob": "^7.2.3",
     "globals": "^15.11.0",
     "gradient-string": "^2.0.2",
-    "history": "^4.10.1",
     "html-webpack-plugin": "5.6.0",
     "identity-obj-proxy": "3.0.0",
     "image-minimizer-webpack-plugin": "3.8.3",
@@ -112,7 +111,7 @@
     "ts-loader": "^9.5.1",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.11.0",
-    "universal-cookie": "^4.0.4",
+    "universal-cookie": "^8.0.1",
     "url-loader": "^4.1.1",
     "uuid": "^11.0.2",
     "webpack": "^5.97.1",
@@ -142,7 +141,7 @@
     "nodemon": "^3.1.4"
   },
   "peerDependencies": {
-    "@openedx/paragon": "^22.20.1",
+    "@openedx/paragon": "^22.20.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^8.1.3",

--- a/runtime/config/index.ts
+++ b/runtime/config/index.ts
@@ -123,14 +123,13 @@ let siteConfig: SiteConfig = {
   apps: [],
   externalRoutes: [],
   externalLinkUrlOverrides: [],
+  mfeConfigApiUrl: null,
   accessTokenCookieName: 'edx-jwt-cookie-header-payload',
   csrfTokenApiPath: '/csrf/api/v1/token',
   ignoredErrorRegex: null,
   languagePreferenceCookieName: 'openedx-language-preference',
-  publicPath: '/',
   refreshAccessTokenApiPath: '/login_refresh',
   userInfoCookieName: 'edx-user-info',
-  mfeConfigApiUrl: null,
   segmentKey: null,
 };
 

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -78,7 +78,6 @@ export {
 export {
   auth,
   getBasename,
-  getHistory,
   initError,
   initialize
 } from './initialize';
@@ -125,11 +124,9 @@ export {
 export {
   camelCaseObject,
   convertKeyNames,
-  getPath,
   getQueryParameters,
   isValidVariableName,
   modifyObjectKeys,
-  parseURL,
   snakeCaseObject
 } from './utils';
 

--- a/runtime/initialize.js
+++ b/runtime/initialize.js
@@ -47,10 +47,6 @@
  * @module Initialization
  */
 
-import {
-  createBrowserHistory,
-  createMemoryHistory
-} from 'history';
 /*
 This 'site.config' package is a special 'magic' alias in our webpack configuration in the `config`
 folder. It points at an `site.config.tsx` file in the root of a site's repository.
@@ -94,30 +90,15 @@ import {
 } from './logging';
 import { GoogleAnalyticsLoader } from './scripts';
 import { publish } from './subscriptions';
-import { getPath } from './utils';
 
 /**
- * A browser history or memory history object created by the [history](https://github.com/ReactTraining/history)
- * package.  Applications are encouraged to use this history object, rather than creating their own,
- * as behavior may be undefined when managing history via multiple mechanisms/instances. Note that
- * in environments where browser history may be inaccessible due to `window` being undefined, this
- * falls back to memory history.
- */
-export const getHistory = () => ((typeof window !== 'undefined')
-  ? createBrowserHistory({ basename: getPath(getSiteConfig().publicPath) })
-  : createMemoryHistory());
-
-/**
- * The string basename that is the root directory of this MFE.
+ * If set in configuration, a basename will be prepended to all relative routes under BrowserRouter.
  *
- * In devstack, this should always just return "/", because each MFE is in its own server/domain.
- *
- * In Tutor, all MFEs are deployed to a common server, each under a different top-level directory.
- * The basename is the root path for a given MFE, e.g. "/library-authoring". It is set by tutor-mfe
- * as an ENV variable in the Docker file, and we read it here from that configuration so that it
- * can be passed into a Router later.
+ * Unlike webpack's publicPath, the basename cannot be auto-discovered, so when publicPath is set
+ * (or when it's set to 'auto' and the site is being served from a path other than '/') this
+ * needs to be configured.
  */
-export const getBasename = () => getPath(getSiteConfig().publicPath);
+export const getBasename = () => getSiteConfig().basename;
 
 /**
  * The default handler for the initialization lifecycle's `initError` phase.  Logs the error to the

--- a/runtime/initialize.test.js
+++ b/runtime/initialize.test.js
@@ -1,5 +1,3 @@
-import { createBrowserHistory } from 'history';
-
 import {
   SITE_ANALYTICS_INITIALIZED,
   SITE_AUTH_INITIALIZED,
@@ -10,7 +8,7 @@ import {
   SITE_PUBSUB_INITIALIZED,
   SITE_READY,
 } from './constants';
-import { getHistory, initialize } from './initialize';
+import { initialize } from './initialize';
 
 import { configureAnalytics, SegmentAnalyticsService } from './analytics';
 import {
@@ -38,7 +36,6 @@ jest.mock('./auth');
 jest.mock('./analytics');
 jest.mock('./i18n');
 jest.mock('./auth/LocalForageCache');
-jest.mock('history');
 
 let config = null;
 const newConfig = {
@@ -354,16 +351,6 @@ describe('initialize', () => {
       expect(ensureAuthenticatedUser).not.toHaveBeenCalled();
       expect(hydrateAuthenticatedUser).not.toHaveBeenCalled();
       expect(logError).not.toHaveBeenCalled();
-    });
-  });
-});
-
-describe('history', () => {
-  it('browser history called by default path', async () => {
-    getHistory();
-    // import history from initialize;
-    expect(createBrowserHistory).toHaveBeenCalledWith({
-      basename: '/',
     });
   });
 });

--- a/runtime/site.config.test.tsx
+++ b/runtime/site.config.test.tsx
@@ -7,6 +7,7 @@ const siteConfig: SiteConfig = {
   lmsBaseUrl: 'http://localhost:18000',
   loginUrl: 'http://localhost:18000/login',
   logoutUrl: 'http://localhost:18000/logout',
+
   environment: EnvironmentTypes.TEST,
   apps: [{
     appId: 'test-app',
@@ -24,10 +25,9 @@ const siteConfig: SiteConfig = {
   csrfTokenApiPath: '/csrf/api/v1/token',
   languagePreferenceCookieName: 'openedx-language-preference',
   refreshAccessTokenApiPath: '/login_refresh',
-  segmentKey: 'segment_whoa',
   userInfoCookieName: 'edx-user-info',
   ignoredErrorRegex: null,
-  publicPath: '/'
+  segmentKey: 'segment_whoa',
 };
 
 export default siteConfig;

--- a/runtime/utils.js
+++ b/runtime/utils.js
@@ -123,42 +123,6 @@ export function convertKeyNames(object, nameMap) {
 }
 
 /**
- * Given a string URL return an element that has been parsed via href.
- * This element has the possibility to return different part of the URL.
-  parser.protocol; // => "http:"
-  parser.hostname; // => "example.com"
-  parser.port;     // => "3000"
-  parser.pathname; // => "/pathname/"
-  parser.search;   // => "?search=test"
-  parser.hash;     // => "#hash"
-  parser.host;     // => "example.com:3000"
- * https://gist.github.com/jlong/2428561
- *
- * @param {string}
- * @returns {Object}
- */
-export function parseURL(url) {
-  if (typeof document !== 'undefined') {
-    const parser = document.createElement('a');
-    parser.href = url;
-    return parser;
-  }
-
-  return {};
-}
-
-/**
- * Given a string URL return the path of the URL
- *
- *
- * @param {string}
- * @returns {string}
- */
-export function getPath(url) {
-  return typeof document !== 'undefined' ? parseURL(url)?.pathname : '';
-}
-
-/**
  * *Deprecated*: A method which converts the supplied query string into an object of
  * key-value pairs and returns it.  Defaults to the current query string - should perform like
  * [window.searchParams](https://developer.mozilla.org/en-US/docs/Web/API/URL/searchParams)

--- a/runtime/utils.test.js
+++ b/runtime/utils.test.js
@@ -2,10 +2,8 @@ import { waitFor } from '@testing-library/react';
 import {
   camelCaseObject,
   convertKeyNames,
-  getPath,
   getQueryParameters,
   modifyObjectKeys,
-  parseURL,
   snakeCaseObject,
 } from '.';
 
@@ -114,99 +112,5 @@ describe('getQueryParameters', () => {
       foo: 'bar',
       baz: '1',
     });
-  });
-});
-
-describe('ParseURL', () => {
-  const testURL = 'http://example.com:3000/pathname/?search=test#hash';
-  const parsedURL = parseURL(testURL);
-  let originalDocument;
-
-  beforeEach(() => {
-    originalDocument = global.document;
-  });
-
-  afterEach(() => {
-    global.document = originalDocument;
-  });
-
-  it('String URL is correctly parsed', () => {
-    expect(parsedURL.toString()).toEqual(testURL);
-    expect(parsedURL.href).toEqual(testURL);
-    expect(typeof (parsedURL)).toEqual('object');
-  });
-
-  it('should return protocol from URL', () => {
-    expect(parsedURL.protocol).toEqual('http:');
-  });
-
-  it('should return hostname from URL', () => {
-    expect(parsedURL.hostname).toEqual('example.com');
-  });
-
-  it('should return port from URL', () => {
-    expect(parsedURL.port).toEqual('3000');
-  });
-
-  it('should return pathname from URL', () => {
-    expect(parsedURL.pathname).toEqual('/pathname/');
-  });
-
-  it('should return search rom URL', () => {
-    expect(parsedURL.search).toEqual('?search=test');
-  });
-
-  it('should return hash from URL', () => {
-    expect(parsedURL.hash).toEqual('#hash');
-  });
-
-  it('should return host from URL', () => {
-    expect(parsedURL.host).toEqual('example.com:3000');
-  });
-
-  it('should return empty object in case of document being undefined', () => {
-    global.document = undefined;
-
-    waitFor(() => {
-      expect(parseURL(testURL)).toEqual({});
-    });
-  });
-});
-
-describe('getPath', () => {
-  it('Path is retrieved with full url', () => {
-    const testURL = 'http://example.com:3000/pathname/?search=test#hash';
-
-    expect(getPath(testURL)).toEqual('/pathname/');
-  });
-
-  it('Path is retrieved with only path', () => {
-    const testURL = '/learning/';
-
-    expect(getPath(testURL)).toEqual('/learning/');
-  });
-
-  it('Path is retrieved without protocol', () => {
-    const testURL = '//example.com:3000/accounts/';
-
-    expect(getPath(testURL)).toEqual('/accounts/');
-  });
-
-  it('Path is retrieved with base `/`', () => {
-    const testURL = '/';
-
-    expect(getPath(testURL)).toEqual('/');
-  });
-
-  it('Path is retrieved without port', () => {
-    const testURL = 'https://example.com/accounts/';
-
-    expect(getPath(testURL)).toEqual('/accounts/');
-  });
-
-  it('Path is retrieved without CDN shape', () => {
-    const testURL = 'https://d20blt6w1kfasr.cloudfront.net/learning/';
-
-    expect(getPath(testURL)).toEqual('/learning/');
   });
 });

--- a/shell/site.config.dev.tsx
+++ b/shell/site.config.dev.tsx
@@ -11,7 +11,7 @@ import userConfig from './dev-site/user/userConfig';
 
 import './app.scss';
 
-const config: SiteConfig = {
+const siteConfig: SiteConfig = {
   apps: [
     defaultShellConfig,
     defaultHeaderConfig,
@@ -44,4 +44,4 @@ const config: SiteConfig = {
   mfeConfigApiUrl: 'http://apps.local.openedx.io:8080/api/mfe_config/v1',
 };
 
-export default config;
+export default siteConfig;

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -16,7 +16,7 @@
       },
       "peerDependencies": {
         "@openedx/frontend-base": "file:../openedx-frontend-base-1.0.0.tgz",
-        "@openedx/paragon": "^22.20.1",
+        "@openedx/paragon": "^22.20.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^8.1.3",
@@ -3635,7 +3635,7 @@
     "node_modules/@openedx/frontend-base": {
       "version": "1.0.0",
       "resolved": "file:../openedx-frontend-base-1.0.0.tgz",
-      "integrity": "sha512-b6kuLifQ//s6Ka5flz8ToxGkGLET7oUyqQblItmNEmlqfEk2AWq7NzQrswgQwgQwRSt/FnnCoDeoE26aSFu66w==",
+      "integrity": "sha512-XnYr5IYwgivxS9/V0oKWw9GVUDhIhuYVIIfigAlbUhLF/IKwl8a/n02jn6x8NcnEEu3iW7TisGF2/vK7qY04iA==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -3676,7 +3676,6 @@
         "glob": "^7.2.3",
         "globals": "^15.11.0",
         "gradient-string": "^2.0.2",
-        "history": "^4.10.1",
         "html-webpack-plugin": "5.6.0",
         "identity-obj-proxy": "3.0.0",
         "image-minimizer-webpack-plugin": "3.8.3",
@@ -3738,9 +3737,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.20.1.tgz",
-      "integrity": "sha512-0P+VResXaBdAauMdChxg1x4cnBdxYK7UZoXAtJn8zSnLR5sxMvlhfKdktW1Si7K5cVkkeCoDF41ZjOJ0aYILKQ==",
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.20.2.tgz",
+      "integrity": "sha512-4dGRGA/tz5uYebGJn0iLCcGWlvkleCq8WRNtVNWIf1jqzwea2fiVO8qxLNaFvIhpdR/jkzFjgdgY3ftj0rqOgQ==",
       "license": "Apache-2.0",
       "peer": true,
       "workspaces": [
@@ -9739,21 +9738,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -15638,13 +15622,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/resolve-url-loader": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
@@ -17687,20 +17664,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -18390,13 +18353,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/varint": {
       "version": "6.0.0",

--- a/test-site/package.json
+++ b/test-site/package.json
@@ -14,7 +14,7 @@
   "license": "AGPL-3.0",
   "peerDependencies": {
     "@openedx/frontend-base": "file:../openedx-frontend-base-1.0.0.tgz",
-    "@openedx/paragon": "^22.20.1",
+    "@openedx/paragon": "^22.20.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^8.1.3",

--- a/test-site/site.config.build.tsx
+++ b/test-site/site.config.build.tsx
@@ -1,9 +1,19 @@
 import { defaultFooterConfig, defaultHeaderConfig, defaultShellConfig, EnvironmentTypes, SiteConfig } from '@openedx/frontend-base';
 
 import { authenticatedPageConfig, examplePageConfig, iframeWidgetConfig } from './src';
+
 import './src/site.scss';
 
-const config: SiteConfig = {
+const siteConfig: SiteConfig = {
+  siteId: 'test',
+  siteName: 'Test Site',
+  baseUrl: 'http://apps.local.openedx.io:8080',
+  lmsBaseUrl: 'http://local.openedx.io:8000',
+  loginUrl: 'http://local.openedx.io:8000/login',
+  logoutUrl: 'http://local.openedx.io:8000/logout',
+
+  environment: EnvironmentTypes.PRODUCTION,
+  mfeConfigApiUrl: 'http://apps.local.openedx.io:8080/api/mfe_config/v1',
   apps: [
     defaultShellConfig,
     defaultHeaderConfig,
@@ -12,14 +22,6 @@ const config: SiteConfig = {
     authenticatedPageConfig,
     iframeWidgetConfig,
   ],
-
-  environment: EnvironmentTypes.PRODUCTION,
-  baseUrl: 'http://localhost:8080',
-  lmsBaseUrl: 'http://localhost:18000',
-  loginUrl: 'http://localhost:18000/login',
-  logoutUrl: 'http://localhost:18000/logout',
-  siteName: 'localhost',
-  siteId: 'test',
 };
 
-export default config;
+export default siteConfig;

--- a/test-site/site.config.dev.tsx
+++ b/test-site/site.config.dev.tsx
@@ -1,8 +1,19 @@
 import { defaultFooterConfig, defaultHeaderConfig, defaultShellConfig, EnvironmentTypes, SiteConfig } from '@openedx/frontend-base';
+
 import { authenticatedPageConfig, examplePageConfig, iframeWidgetConfig } from './src';
+
 import './src/site.scss';
 
 const siteConfig: SiteConfig = {
+  siteId: 'test',
+  siteName: 'Test Site',
+  baseUrl: 'http://apps.local.openedx.io:8080',
+  lmsBaseUrl: 'http://local.openedx.io:8000',
+  loginUrl: 'http://local.openedx.io:8000/login',
+  logoutUrl: 'http://local.openedx.io:8000/logout',
+
+  environment: EnvironmentTypes.DEVELOPMENT,
+  mfeConfigApiUrl: 'http://apps.local.openedx.io:8080/api/mfe_config/v1',
   apps: [
     defaultShellConfig,
     defaultHeaderConfig,
@@ -11,19 +22,6 @@ const siteConfig: SiteConfig = {
     authenticatedPageConfig,
     iframeWidgetConfig,
   ],
-
-  siteId: 'test',
-  baseUrl: 'http://apps.local.openedx.io:8080',
-  environment: EnvironmentTypes.DEVELOPMENT,
-  siteName: 'My Open edX Site',
-
-  // Frontend URLs
-  loginUrl: 'http://local.openedx.io:8000/login',
-  logoutUrl: 'http://local.openedx.io:8000/logout',
-
-  // API URLs
-  lmsBaseUrl: 'http://local.openedx.io:8000',
-  mfeConfigApiUrl: 'http://apps.local.openedx.io:8080/api/mfe_config/v1',
 };
 
 export default siteConfig;

--- a/tools/cli/commands/serve.ts
+++ b/tools/cli/commands/serve.ts
@@ -20,43 +20,20 @@ function isDirectoryEmpty(directoryPath: string) {
 const buildPath = path.join(process.cwd(), 'dist');
 const buildPathIndex = path.join(buildPath, 'index.html');
 
-const fallbackPort = 8080;
-
 if (isDirectoryEmpty(buildPath)) {
   const formattedBuildCmd = chalk.bold.redBright('``npm run build``');
   console.log(chalk.bold.red(`ERROR: No build found. Please run ${formattedBuildCmd} first.`));
 } else {
-  let configuredPort;
-
-  try {
-    configuredPort = require(path.join(process.cwd(), 'site.config.tsx'))?.PORT;
-  } catch (error) {
-    // Pass. Consuming applications may not have an `site.config.tsx` file. This is OK.
-  }
-
-  if (!configuredPort) {
-    configuredPort = process.env.PORT;
-  }
-
-  // No `PORT` found in `site.config.tsx` and/or `.env.development|private`, so output a warning.
-  if (!configuredPort) {
-    const formattedEnvDev = chalk.bold.yellowBright('.env.development');
-    const formattedEnvConfig = chalk.bold.yellowBright('site.config.tsx');
-    const formattedPort = chalk.bold.yellowBright(fallbackPort);
-    console.log(chalk.yellow(`No port found in ${formattedEnvDev} and/or ${formattedEnvConfig} file(s). Falling back to port ${formattedPort}.\n`));
-  }
-
   const app = express();
-
-  // Fallback to standard example port if no PORT config is set.
-  const PORT = configuredPort || fallbackPort;
 
   app.use(compression());
   app.use(express.static(buildPath));
-
   app.use('*', (req, res) => {
     res.sendFile(buildPathIndex);
   });
+
+  // Fallback to standard example port if no PORT config is set.
+  const PORT = process.env.PORT ?? 8080;
 
   app.listen(PORT, () => {
     const formattedServedFile = chalk.bold.cyanBright(buildPathIndex);

--- a/tools/webpack/common-config/dev/getDevServer.ts
+++ b/tools/webpack/common-config/dev/getDevServer.ts
@@ -6,14 +6,13 @@ import getPublicPath from '../../utils/getPublicPath';
 export default function getDevServer(): Configuration {
   return {
     allowedHosts: 'all',
-    devMiddleware: {
-      publicPath: getPublicPath(),
-    },
     headers: {
       'Access-Control-Allow-Origin': '*',
     },
+    // For obvious reasons, 'auto' won't work for publicPath here, so we
+    // force '/' unless PUBLIC_PATH is set.
     historyApiFallback: {
-      index: path.join(getPublicPath(), 'index.html'),
+      index: path.join(getPublicPath('/'), 'index.html'),
       disableDotRule: true,
     },
     host: 'apps.local.openedx.io',

--- a/tools/webpack/utils/getPublicPath.ts
+++ b/tools/webpack/utils/getPublicPath.ts
@@ -1,3 +1,3 @@
-export default function getPublicPath(defaultPath = '/') {
+export default function getPublicPath(defaultPath = 'auto') {
   return process.env.PUBLIC_PATH ?? defaultPath;
 }

--- a/tools/webpack/webpack.config.build.ts
+++ b/tools/webpack/webpack.config.build.ts
@@ -40,7 +40,7 @@ const config: Configuration = {
   output: {
     filename: '[name].[chunkhash].js',
     path: path.resolve(process.cwd(), 'dist'),
-    publicPath: getPublicPath('auto'),
+    publicPath: getPublicPath(),
     clean: true, // Clean the output directory before emit.
   },
   resolve: {

--- a/tools/webpack/webpack.config.dev.shell.ts
+++ b/tools/webpack/webpack.config.dev.shell.ts
@@ -39,7 +39,7 @@ const config: Configuration = {
   },
   output: {
     path: path.resolve(process.cwd(), './dist'),
-    publicPath: getPublicPath('auto'),
+    publicPath: getPublicPath(),
   },
   resolve: {
     alias: {

--- a/tools/webpack/webpack.config.dev.ts
+++ b/tools/webpack/webpack.config.dev.ts
@@ -38,7 +38,7 @@ const config: Configuration = {
   },
   output: {
     path: path.resolve(process.cwd(), './dist'),
-    publicPath: getPublicPath('auto'),
+    publicPath: getPublicPath(),
   },
   resolve: {
     alias: {

--- a/types.ts
+++ b/types.ts
@@ -49,10 +49,10 @@ export type LocalizedMessages = Record<string, Record<string, string>>;
 export interface OptionalSiteConfig {
   // Site environment
   environment: EnvironmentTypes,
-  publicPath: string,
 
   // Apps, routes, and URLs
   apps: App[],
+  basename: string,
   externalRoutes: ExternalRoute[],
   externalLinkUrlOverrides: string[],
   mfeConfigApiUrl: string | null,


### PR DESCRIPTION
This separates webpack's publicPath from react-router's basename.  They have similar effects (and still need to be set in conjunction in dev mode, though not in a production build, where publicPath is set to 'auto'),but it is very confusing to give them the same name in configuration.  This led to a lot off unnecessary path manipulation workarounds that have also been removed from the code.

Relatedly, this also removes support for `history` and its similarly confusing reliance on basename, which is not even supported on newer versions of the package, anyway.  Consuming apps should be using `useNavigate()` instead.