### PR TITLE
conditional render fix

### DIFF
--- a/runtime/slots/Slot.test.tsx
+++ b/runtime/slots/Slot.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { useContext } from 'react';
 import { useLayoutForSlotId } from './layout/hooks';
 import Slot from './Slot';
@@ -9,7 +10,7 @@ jest.mock('./layout/hooks');
 describe('Slot component', () => {
   it('renders with default layout', () => {
     (useLayoutForSlotId as jest.Mock).mockReturnValue(null);
-    const { container } = render(<Slot id="test-slot.ui" />);
+    const { container } = render(<MemoryRouter><Slot id="test-slot.ui" /></MemoryRouter>);
     expect(container).toBeEmptyDOMElement();
   });
 

--- a/runtime/slots/layout/hooks.ts
+++ b/runtime/slots/layout/hooks.ts
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode, useCallback, useEffect, useState } from 'react';
+import { ComponentType, ReactNode, useEffect, useState } from 'react';
 import { useSlotContext, useSlotOperations } from '../hooks';
 import { isSlotOperationConditionSatisfied } from '../utils';
 import { LayoutComponentProps, LayoutElementProps, LayoutOperation } from './types';
@@ -43,25 +43,23 @@ export function useLayoutOptions() {
 
 export function useLayoutOptionsForId(id: string) {
   const operations = useSlotOperations(id);
-
-  const findOptions = useCallback(() => {
-    let nextOptions: Record<string, unknown> = {};
-    for (const operation of operations) {
-      if (isSlotOperationConditionSatisfied(operation)) {
-        if (isLayoutOptionsOperation(operation)) {
-          nextOptions = { ...nextOptions, ...operation.options };
-        }
-      }
-    }
-    return nextOptions;
-  }, [operations]);
-
-  const [options, setOptions] = useState<Record<string, unknown>>(findOptions());
+  const [options, setOptions] = useState<Record<string, unknown>>({});
 
   useEffect(() => {
-    const nextOptions = findOptions();
-    setOptions(nextOptions);
-  }, [operations, findOptions, id]);
+    const findOptions = () => {
+      let nextOptions: Record<string, unknown> = {};
+      for (const operation of operations) {
+        if (isSlotOperationConditionSatisfied(operation)) {
+          if (isLayoutOptionsOperation(operation)) {
+            nextOptions = { ...nextOptions, ...operation.options };
+          }
+        }
+      }
+      return nextOptions;
+    };
+
+    setOptions(findOptions());
+  }, [operations]);
 
   return options;
 }

--- a/shell/dev-site/header/headerConfig.tsx
+++ b/shell/dev-site/header/headerConfig.tsx
@@ -1,4 +1,3 @@
-import { NavDropdownMenuSlot } from '../..';
 import { WidgetOperationTypes } from '../../../runtime';
 import { App } from '../../../types';
 import LinkMenuItem from '../../menus/LinkMenuItem';
@@ -17,52 +16,6 @@ const config: App = {
           url="#"
           variant="navLink"
         />
-      )
-    },
-    {
-      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
-      relatedId: 'header.learnerDashboard.link',
-      op: WidgetOperationTypes.OPTIONS,
-      options: {
-        title: 'Booyah yeah',
-      }
-    },
-    {
-      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
-      id: 'header.learnerDashboard.linkAfter3',
-      op: WidgetOperationTypes.INSERT_AFTER,
-      relatedId: 'header.learnerDashboard.link3',
-      element: (<LinkMenuItem label="Link After 3" url="#" variant="navLink" />
-      )
-    },
-    {
-      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
-      id: 'header.booyah.primaryLinks.dropdown',
-      op: WidgetOperationTypes.PREPEND,
-      element: (
-        <NavDropdownMenuSlot id="org.openedx.frontend.slot.header.primaryLinksDropdown.v1" label="Resources" />
-      )
-    },
-    {
-      slotId: 'org.openedx.frontend.slot.header.primaryLinksDropdown.v1',
-      id: 'header.booyah.primaryLinks.dropdown.1',
-      op: WidgetOperationTypes.APPEND,
-      element: (
-        <LinkMenuItem label="Resource 1" url="#" variant="dropdownItem" />
-      )
-    },
-    {
-      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
-      id: 'header.learnerDashboard.link3',
-      op: WidgetOperationTypes.APPEND,
-      element: (<LinkMenuItem label="Link 3" url="#" variant="navLink" />
-      )
-    },
-    {
-      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
-      id: 'header.learnerDashboard.link4',
-      op: WidgetOperationTypes.APPEND,
-      element: (<LinkMenuItem label="Link 4" url="#" variant="navLink" />
       )
     },
   ]

--- a/shell/dev-site/slot-showcase/index.tsx
+++ b/shell/dev-site/slot-showcase/index.tsx
@@ -1,3 +1,5 @@
+import { NavDropdownMenuSlot } from '../..';
+import LinkMenuItem from '../../menus/LinkMenuItem';
 import { LayoutOperationTypes, WidgetOperationTypes, useSlotContext } from '../../../runtime';
 import { App } from '../../../types';
 import HorizontalSlotLayout from './HorizontalSlotLayout';
@@ -300,6 +302,69 @@ const config: App = {
       op: WidgetOperationTypes.OPTIONS,
       options: {
         title: (<Title title="Bar" op="WidgetOperationTypes.OPTIONS" />),
+      }
+    },
+
+    // Header
+    {
+      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
+      relatedId: 'header.learnerDashboard.link',
+      op: WidgetOperationTypes.OPTIONS,
+      options: {
+        title: 'Courses (modified)',
+      },
+      condition: {
+        active: ['slotShowcase'],
+      }
+    },
+    {
+      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
+      id: 'header.learnerDashboard.linkAfter3',
+      op: WidgetOperationTypes.INSERT_AFTER,
+      relatedId: 'header.learnerDashboard.link3',
+      element: (<LinkMenuItem label="Link After 3" url="#" variant="navLink" />),
+      condition: {
+        active: ['slotShowcase'],
+      }
+    },
+    {
+      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
+      id: 'header.coursesModified.primaryLinks.dropdown',
+      op: WidgetOperationTypes.PREPEND,
+      element: (
+        <NavDropdownMenuSlot id="org.openedx.frontend.slot.header.primaryLinksDropdown.v1" label="Resources" />
+      ),
+      condition: {
+        active: ['slotShowcase']
+      }
+    },
+    {
+      slotId: 'org.openedx.frontend.slot.header.primaryLinksDropdown.v1',
+      id: 'header.coursesModified.primaryLinks.dropdown.1',
+      op: WidgetOperationTypes.APPEND,
+      element: (
+        <LinkMenuItem label="Resource 1" url="#" variant="dropdownItem" />
+      ),
+      condition: {
+        active: ['slotShowcase'],
+      }
+    },
+    {
+      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
+      id: 'header.learnerDashboard.link3',
+      op: WidgetOperationTypes.APPEND,
+      element: (<LinkMenuItem label="Link 3" url="#" variant="navLink" />),
+      condition: {
+        active: ['slotShowcase'],
+      }
+    },
+    {
+      slotId: 'org.openedx.frontend.slot.header.primaryLinks.v1',
+      id: 'header.learnerDashboard.link4',
+      op: WidgetOperationTypes.APPEND,
+      element: (<LinkMenuItem label="Link 4" url="#" variant="navLink" />),
+      condition: {
+        active: ['slotShowcase'],
       }
     },
   ]

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -3635,7 +3635,7 @@
     "node_modules/@openedx/frontend-base": {
       "version": "1.0.0",
       "resolved": "file:../openedx-frontend-base-1.0.0.tgz",
-      "integrity": "sha512-XnYr5IYwgivxS9/V0oKWw9GVUDhIhuYVIIfigAlbUhLF/IKwl8a/n02jn6x8NcnEEu3iW7TisGF2/vK7qY04iA==",
+      "integrity": "sha512-+sSctoxhKgobZBj2YARFscfcwxDMu6eQJcaJwSP/zrUkcrsh4jCgyE+ZGii3stgZiliNj9mKve9TMbFkw0dYtQ==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -3711,7 +3711,7 @@
         "ts-loader": "^9.5.1",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.11.0",
-        "universal-cookie": "^4.0.4",
+        "universal-cookie": "^8.0.1",
         "url-loader": "^4.1.1",
         "uuid": "^11.0.2",
         "webpack": "^5.97.1",
@@ -3727,7 +3727,7 @@
         "transifex-utils.js": "tools/dist/cli/scripts/transifex-utils.js"
       },
       "peerDependencies": {
-        "@openedx/paragon": "^22.20.1",
+        "@openedx/paragon": "^22.20.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-redux": "^8.1.3",
@@ -4146,13 +4146,6 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
-      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -18107,24 +18100,23 @@
       }
     },
     "node_modules/universal-cookie": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
-      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-8.0.1.tgz",
+      "integrity": "sha512-B6ks9FLLnP1UbPPcveOidfvB9pHjP+wekP2uRYB9YDfKVpvcjKgy1W5Zj+cEXJ9KTPnqOKGfVDQBmn8/YCQfRg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@types/cookie": "^0.3.3",
-        "cookie": "^0.4.0"
+        "cookie": "^1.0.2"
       }
     },
     "node_modules/universal-cookie/node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
       }
     },
     "node_modules/universalify": {


### PR DESCRIPTION
This fixes a bug where widgets defined with a `condition: { active }` would not re-render correctly on navigation to/from the correspondingly affected page.

Also includes:

- **refactor: slot hooks without useCallback()**
- **refactor: dev site to demo conditional ops**
- **chore: renegerate test-site package-lock**
