### PR TITLE
fix: work around inotify resource starvation

### DIFF
--- a/tools/webpack/webpack.config.dev.shell.ts
+++ b/tools/webpack/webpack.config.dev.shell.ts
@@ -117,6 +117,11 @@ const config: Configuration = {
   // reloading.
 
   devServer: getDevServer(),
+
+  // Limit the number of watched files to avoid `inotify` resource starvation.
+  watchOptions: {
+    ignored: /node_modules/
+  }
 };
 
 export default config;

--- a/tools/webpack/webpack.config.dev.ts
+++ b/tools/webpack/webpack.config.dev.ts
@@ -85,6 +85,11 @@ const config: Configuration = {
   // reloading.
 
   devServer: getDevServer(),
+
+  // Limit the number of watched files to avoid `inotify` resource starvation.
+  watchOptions: {
+    ignored: /node_modules/
+  }
 };
 
 export default config;


### PR DESCRIPTION
### Description

In order to avoid running out of kernel inotify handles in development environments where it's not possible to raise the corresponding limit, stop watching `node_modules` when running `openedx dev`.

### To reproduce

To reproduce the issue:

```bash
git clone https://github.com/openedx/frontend-template-site.git
cd frontend-template-site
nvm use
npm ci
npm run dev
```

If this doesn't give you the INOTIFY error (which likely means your system's limit is already high enough), install https://github.com/mikesart/inotify-info and run the following in a separate terminal:

```
inotify-info | less
```

The `node` process will be showing above 80 thousand files.

### To test

Check this branch of frontend-base out, and:

```bash
cd frontend-base
nvm use
npm ci
npm run build && npm pack && mv openedx-frontend-base-*.tgz openedx-frontend-base.tgz 
cd ../frontend-template-site
npm i ../frontend-base/openedx-frontend-base.tgz
npm run dev
```

At this point, `inotify-info` should be reporting just 25 files.