### PR TITLE
chore: unsilencing mixed-decls

### DIFF
--- a/tools/webpack/common-config/all/getStylesheetRule.ts
+++ b/tools/webpack/common-config/all/getStylesheetRule.ts
@@ -83,7 +83,7 @@ function getStyleUseConfig(mode: 'dev' | 'production') {
           ],
           // Silences compiler deprecation warnings.  They mostly come from bootstrap and/or paragon.
           quietDeps: true,
-          silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'mixed-decls', 'global-builtin', 'legacy-js-api'],
+          silenceDeprecations: ['abs-percent', 'color-functions', 'import', 'global-builtin', 'legacy-js-api'],
         },
       },
     },


### PR DESCRIPTION
Removing the mixed-decls silence from silence deprecation on stylesheet rules.

Closes https://github.com/openedx/frontend-base/issues/103