### PR TITLE
fix: disable nullish coalescing linting error

### DIFF
--- a/tools/eslint/base.eslint.config.js
+++ b/tools/eslint/base.eslint.config.js
@@ -87,6 +87,7 @@ module.exports = tseslint.config(
         caughtErrors: 'none',
       }],
       '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/prefer-nullish-coalescing': 'off',
       '@stylistic/semi': ['error', 'always', { omitLastInOneLineBlock: true, omitLastInOneLineClassBody: true }],
       '@stylistic/quotes': ['error', 'single', {
         avoidEscape: true,


### PR DESCRIPTION
While I also prefer the nullish coalescing operator wherever possible, it is not strictly equivalent to the alternatives, and thus it should not be forced upon developers.

An example:

https://github.com/openedx/frontend-app-authn/pull/1611/changes/aa5240fe77ed76414921a2c93bd10ea55fa5ffd6#r2619834128