### PR TITLE
Adding settings for using @src as an import alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openedx/frontend-base",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Build tools, setup and config for frontend apps",
   "publishConfig": {
     "access": "public"

--- a/runtime/jest.config.js
+++ b/runtime/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir/__mocks__/file.js',
     '\\.(css|scss)$': require.resolve('identity-obj-proxy'),
     'site.config': '<rootDir>/site.config.test.tsx',
+    '^@src/(.*)$': '<rootDir>/src/$1',
   },
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {

--- a/shell/jest.config.js
+++ b/shell/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/file.js',
     '\\.(css|scss)$': require.resolve('identity-obj-proxy'),
     'site.config': '<rootDir>/site.config.test.tsx',
+    '^@src/(.*)$': '<rootDir>/src/$1',
   },
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {

--- a/tools/jest/jest.config.js
+++ b/tools/jest/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|scss)$': require.resolve('identity-obj-proxy'),
     'site.config': path.resolve(process.cwd(), './site.config.test.tsx'),
+    '^@src/(.*)$': '<rootDir>/src/$1',
   },
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -6,6 +6,9 @@
     "noEmit": false,
     "allowJs": true,
     "resolveJsonModule": true,
+    "paths": {
+      "@src/*": ["./src/*"]
+    }
   },
   "include": [
     "babel/**/*",

--- a/tools/webpack/webpack.config.build.ts
+++ b/tools/webpack/webpack.config.build.ts
@@ -36,6 +36,7 @@ const config: Configuration = {
     alias: {
       ...aliases,
       'site.config': resolvedSiteConfigPath,
+      '@src': path.resolve(process.cwd(), 'src'),
     },
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
   },

--- a/tools/webpack/webpack.config.dev.shell.ts
+++ b/tools/webpack/webpack.config.dev.shell.ts
@@ -34,6 +34,7 @@ const config: Configuration = {
     alias: {
       ...aliases,
       'site.config': resolvedSiteConfigPath,
+      '@src': path.resolve(process.cwd(), 'src'),
     },
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
   },

--- a/tools/webpack/webpack.config.dev.ts
+++ b/tools/webpack/webpack.config.dev.ts
@@ -33,6 +33,7 @@ const config: Configuration = {
     alias: {
       ...aliases,
       'site.config': resolvedSiteConfigPath,
+      '@src': path.resolve(process.cwd(), 'src'),
     },
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist",
+    "paths": {
+      "@src/*": ["./src/*"]
+    }
   },
   "include": [
     "runtime/**/*",


### PR DESCRIPTION
# Description
This pr adds the @src import alias to avoid using `../.` to import from parent folders, use `@src`, e.g. `import { initializeMocks } from '@src/testUtils';` instead of from `'../../../../testUtils'`

Updates all the webpack config files, tsconfigs and jest config files with the `@src` alias, even tho the client project still needs to override the tsconfig since it is not being reflected properly (any idea why?)

Fixes parts of https://github.com/openedx/frontend-app-instruct/issues/76

Tested on the instructor dashboard mfe and works fine.