### PR TITLE
fix: correct script paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,9 +93,9 @@
         "webpack-remove-empty-scripts": "1.0.4"
       },
       "bin": {
-        "intl-imports.js": "tools/dist/cli/scripts/intl-imports.js",
+        "intl-imports.js": "tools/dist/cli/intl-imports.js",
         "openedx": "tools/dist/cli/openedx.js",
-        "transifex-utils.js": "tools/dist/cli/scripts/transifex-utils.js"
+        "transifex-utils.js": "tools/dist/cli/transifex-utils.js"
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "/types.ts"
   ],
   "bin": {
-    "intl-imports.js": "tools/dist/cli/scripts/intl-imports.js",
+    "intl-imports.js": "tools/dist/cli/intl-imports.js",
     "openedx": "tools/dist/cli/openedx.js",
-    "transifex-utils.js": "tools/dist/cli/scripts/transifex-utils.js"
+    "transifex-utils.js": "tools/dist/cli/transifex-utils.js"
   },
   "scripts": {
     "build": "make build",

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -3812,9 +3812,9 @@
         "webpack-remove-empty-scripts": "1.0.4"
       },
       "bin": {
-        "intl-imports.js": "tools/dist/cli/scripts/intl-imports.js",
+        "intl-imports.js": "tools/dist/cli/intl-imports.js",
         "openedx": "tools/dist/cli/openedx.js",
-        "transifex-utils.js": "tools/dist/cli/scripts/transifex-utils.js"
+        "transifex-utils.js": "tools/dist/cli/transifex-utils.js"
       },
       "peerDependencies": {
         "@openedx/paragon": "^23.4.5",

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -1,4 +1,4 @@
-# i18n/scripts
+# cli
 
 This directory contains the `transifex-utils.js` and `intl-imports.js` files which are shared across all micro-frontends.
 
@@ -6,16 +6,18 @@ The package.json of `frontend-base` includes the following sections:
 
 ```
   "bin": {
-    "intl-imports.js": "i18n/scripts/intl-imports.js"
-    "transifex-utils.js": "i18n/scripts/transifex-utils.js"
+    "intl-imports.js": "tools/dist/cli/intl-imports.js",
+    "openedx": "tools/dist/cli/openedx.js",
+    "transifex-utils.js": "tools/dist/cli/transifex-utils.js"
   },
 ```
 
-This config block causes boths scripts to be copied to the following path when `frontend-base` is installed as a
+This config block causes the scripts to be copied to the following path when `frontend-base` is installed as a
 dependency of a micro-frontend:
 
 ```
 /node_modules/.bin/intl-imports.js
+/node_modules/.bin/openedx
 /node_modules/.bin/transifex-utils.js
 ```
 
@@ -26,4 +28,4 @@ intl_imports = ./node_modules/.bin/intl-imports.js
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 ```
 
-So if you delete either of the files or the `scripts` directory, you'll break all micro-frontend builds. Happy coding!
+So if you delete either of the files or the `cli` directory, you'll break all micro-frontend builds. Happy coding!


### PR DESCRIPTION
Update paths to `intl-imports.js` and `transifex-utils.js` so that they install correctly to `node_modules/.bin`. Update related documentation.

Fixes https://github.com/openedx/frontend-base/issues/122.