### PR TITLE
fix: validate runtime config parsing

### DIFF
--- a/runtime/initialize.js
+++ b/runtime/initialize.js
@@ -181,10 +181,13 @@ async function runtimeConfig() {
       }
 
       const { data } = await apiService.get(runtimeConfigUrl.toString(), apiConfig);
+      if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        throw new TypeError('Runtime config must be a valid JSON object.');
+      }
       mergeSiteConfig(data, { limitAppMergeToConfig: true });
     }
   } catch (error) {
-    console.error('Error with config API', error.message);
+    console.error('Error with config API:', error.message);
   }
 }
 

--- a/runtime/initialize.test.js
+++ b/runtime/initialize.test.js
@@ -377,7 +377,7 @@ describe('initialize', () => {
       });
 
       expect(configureCache).toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalledWith('Error with config API', 'Api fails');
+      expect(console.error).toHaveBeenCalledWith('Error with config API:', 'Api fails');
       expect(configureLogging).toHaveBeenCalledWith(NewRelicLoggingService, { config });
       expect(configureAuth).toHaveBeenCalledWith(AxiosJwtAuthService, {
         loggingService: getLoggingService(),


### PR DESCRIPTION
I ran into a "silent failure" issue when I accidentally left a trailing comma in my runtime config JSON. This just updates the `runtimeConfig()` function to verify the `data` we get from axios is actually an object before trying to merge.