### PR TITLE
feat: add headerLogoImageUrl site config option

### DIFF
--- a/shell/Logo.test.tsx
+++ b/shell/Logo.test.tsx
@@ -1,9 +1,22 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
+import { getSiteConfig, mergeSiteConfig, setSiteConfig } from '../runtime/config';
+import { SiteConfig } from '../types';
 import Logo from './Logo';
 
 describe('Logo component', () => {
-  it('renders the image with default URL when no props are provided', async () => {
+  let originalConfig: SiteConfig;
+
+  beforeEach(() => {
+    // Shallow clone is sufficient here since we only modify headerLogoImageUrl, a top-level field.
+    originalConfig = { ...getSiteConfig() };
+  });
+
+  afterEach(() => {
+    setSiteConfig(originalConfig);
+  });
+
+  it('renders the image with default URL when no imageUrl prop is provided and headerLogoImageUrl is not set in site config', async () => {
     const { getByRole, queryByRole } = render(<Logo />);
     const image = getByRole('img');
     expect(image).toHaveAttribute('src', 'https://edx-cdn.org/v3/default/logo.svg');
@@ -11,7 +24,7 @@ describe('Logo component', () => {
     expect(link).toBeNull();
   });
 
-  it('renders the image with provided imageUrl', () => {
+  it('renders the image with provided imageUrl', async () => {
     const testUrl = 'https://example.com/test-logo.svg';
     const { getByRole, queryByRole } = render(<Logo imageUrl={testUrl} />);
     const image = getByRole('img');
@@ -20,7 +33,17 @@ describe('Logo component', () => {
     expect(link).toBeNull();
   });
 
-  it('renders the image wrapped in a Hyperlink when destinationUrl is provided', () => {
+  it('renders the image with headerLogoImageUrl when set in site config and no imageUrl prop is provided', async () => {
+    const configLogoUrl = 'https://example.com/config-logo.svg';
+    mergeSiteConfig({ headerLogoImageUrl: configLogoUrl });
+    const { getByRole, queryByRole } = render(<Logo />);
+    const image = getByRole('img');
+    expect(image).toHaveAttribute('src', configLogoUrl);
+    const link = queryByRole('link');
+    expect(link).toBeNull();
+  });
+
+  it('renders the image wrapped in a Hyperlink when destinationUrl is provided', async () => {
     const testDestinationUrl = 'https://example.com';
     const { getByRole } = render(<Logo destinationUrl={testDestinationUrl} />);
     const link = getByRole('link');

--- a/shell/Logo.tsx
+++ b/shell/Logo.tsx
@@ -1,5 +1,6 @@
 import { IntlProvider } from 'react-intl';
 import { Hyperlink, Image } from '@openedx/paragon';
+import { getSiteConfig } from '../runtime/config';
 
 interface LogoProps {
   imageUrl?: string,
@@ -7,7 +8,7 @@ interface LogoProps {
 }
 
 export default function Logo({
-  imageUrl = 'https://edx-cdn.org/v3/default/logo.svg',
+  imageUrl = getSiteConfig().headerLogoImageUrl ?? 'https://edx-cdn.org/v3/default/logo.svg',
   destinationUrl
 }: LogoProps) {
   const image = (

--- a/types.ts
+++ b/types.ts
@@ -59,6 +59,7 @@ export interface OptionalSiteConfig {
   externalRoutes: ExternalRoute[],
   externalLinkUrlOverrides: string[],
   runtimeConfigJsonUrl: string | null,
+  headerLogoImageUrl: string,
 
   // Theme
   theme: Theme,


### PR DESCRIPTION
## Summary

- Adds a new optional `headerLogoImageUrl` field to `SiteConfig` allowing the header logo image URL to be set via site configuration
- Updates `Logo` component to read from `getSiteConfig().headerLogoImageUrl` at render time, falling back to the existing default CDN URL
- Adds tests covering all three resolution scenarios: explicit prop, site config value, and fallback default

Closes #143

## Test plan

- [ ] `headerLogoImageUrl` set in site config → header logo uses that URL
- [ ] `imageUrl` prop passed directly to `Logo` → prop takes precedence
- [ ] Neither set → falls back to `https://edx-cdn.org/v3/default/logo.svg`
- [ ] Run `jest shell/Logo.test.tsx` — all tests pass

<details>
<summary><h3>Log</h3></summary>

# Work Log

## Issue
[openedx/frontend-base#143](https://github.com/openedx/frontend-base/issues/143) — Set header logo URL via configuration

## Changes

### `frontend-base`

**`types.ts`**
- Added `headerLogoImageUrl: string` to `OptionalSiteConfig`

**`shell/Logo.tsx`**
- Imported `getSiteConfig` from `../runtime/config`
- Updated `imageUrl` default parameter to read `getSiteConfig().headerLogoImageUrl`, falling back to the hardcoded CDN URL

**`shell/Logo.test.tsx`**
- Added test: renders with `headerLogoImageUrl` when set in site config and no `imageUrl` prop is provided
- Updated existing test names to be more explicit about conditions
- Used `mergeSiteConfig`/`setSiteConfig` for config state setup/teardown rather than `jest.mock('../runtime/config')` — mocking the config module caused test runtime to increase significantly

### `frontend-app-learner-dashboard`
- No changes needed (default fallback covers the case where `headerLogoImageUrl` is not set)
- Verified manually by setting `headerLogoImageUrl: 'https://picsum.dev/150/100'` in `site.config.dev.tsx`

## Open items
- `beforeEach` snapshot uses `{ ...getSiteConfig() }` (shallow copy) — sufficient for current tests but worth noting it won't handle nested refs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)