### PR TITLE
feat: support commonAppConfig site config option

### DIFF
--- a/runtime/config/index.test.ts
+++ b/runtime/config/index.test.ts
@@ -1,6 +1,8 @@
 import { CONFIG_CHANGED } from '../constants';
 import * as subscriptions from '../subscriptions';
 import {
+  addAppConfigs,
+  getAppConfig,
   getSiteConfig,
   mergeSiteConfig,
   setSiteConfig,
@@ -293,6 +295,59 @@ describe('mergeSiteConfig', () => {
 
       // Config should be unchanged
       expect(getSiteConfig().apps![0].config!.ORIGINAL).toBe('value');
+    });
+  });
+
+  describe('getAppConfig with commonAppConfig', () => {
+    it('should return commonAppConfig values for an app with no config', () => {
+      setSiteConfig({
+        ...defaultSiteConfig,
+        commonAppConfig: { COMMON_KEY: 'common-value' },
+        apps: [{ appId: 'test-app' }],
+      });
+      addAppConfigs();
+
+      const config = getAppConfig('test-app');
+      expect(config).toEqual({ COMMON_KEY: 'common-value' });
+    });
+
+    it('should let app-specific config override commonAppConfig', () => {
+      setSiteConfig({
+        ...defaultSiteConfig,
+        commonAppConfig: { SHARED: 'common', COMMON_ONLY: 'yes' },
+        apps: [{ appId: 'test-app', config: { SHARED: 'app-specific', APP_ONLY: 'yes' } }],
+      });
+      addAppConfigs();
+
+      const config = getAppConfig('test-app');
+      expect(config).toEqual({
+        SHARED: 'app-specific',
+        COMMON_ONLY: 'yes',
+        APP_ONLY: 'yes',
+      });
+    });
+
+    it('should return app config as-is when commonAppConfig is not set', () => {
+      setSiteConfig({
+        ...defaultSiteConfig,
+        apps: [{ appId: 'test-app', config: { VALUE: 'test' } }],
+      });
+      addAppConfigs();
+
+      const config = getAppConfig('test-app');
+      expect(config).toEqual({ VALUE: 'test' });
+    });
+
+    it('should deep merge commonAppConfig with app config', () => {
+      setSiteConfig({
+        ...defaultSiteConfig,
+        commonAppConfig: { NESTED: { a: 1, b: 2 } },
+        apps: [{ appId: 'test-app', config: { NESTED: { b: 3, c: 4 } } }],
+      });
+      addAppConfigs();
+
+      const config = getAppConfig('test-app');
+      expect(config).toEqual({ NESTED: { a: 1, b: 3, c: 4 } });
     });
   });
 });

--- a/runtime/config/index.ts
+++ b/runtime/config/index.ts
@@ -272,7 +272,11 @@ export function addAppConfigs() {
 }
 
 export function getAppConfig(id: string) {
-  return appConfigs[id];
+  const { commonAppConfig } = getSiteConfig();
+  if (commonAppConfig === undefined) {
+    return appConfigs[id];
+  }
+  return merge({}, commonAppConfig, appConfigs[id]);
 }
 
 export function mergeAppConfig(id: string, newAppConfig: AppConfig) {

--- a/types.ts
+++ b/types.ts
@@ -59,6 +59,7 @@ export interface OptionalSiteConfig {
   externalRoutes: ExternalRoute[],
   externalLinkUrlOverrides: string[],
   runtimeConfigJsonUrl: string | null,
+  commonAppConfig: AppConfig,
   headerLogoImageUrl: string,
 
   // Theme


### PR DESCRIPTION
## Description

Adds a new `commonAppConfig` optional site configuration field.  When set, its values are merged into every app's config via `getAppConfig()` at the lowest priority, so app-specific config always takes precedence.

<details>
<summary>Work log</summary>

1. Read `types.ts` to understand the new `commonAppConfig: AppConfig` field at line 62 in `OptionalSiteConfig`
2. Read `runtime/config/index.ts` to understand how `getAppConfig()`, `addAppConfigs()`, and the `appConfigs` record work
3. Initially proposed merging `commonAppConfig` into `appConfigs` at write time (in `addAppConfigs()`), but user preferred keeping app-specific configs separate and merging at read time
4. Modified `getAppConfig()` to merge `commonAppConfig` from site config as the lowest-priority base using `lodash.merge`, with app-specific config on top
5. Added 4 test cases to `runtime/config/index.test.ts` covering all merge scenarios
6. All 18 tests pass (14 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>