### PR TITLE
fix: revert @src alias in jest configs

### DIFF
--- a/runtime/jest.config.js
+++ b/runtime/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir/__mocks__/file.js',
     '\\.(css|scss)$': require.resolve('identity-obj-proxy'),
     'site.config': '<rootDir>/site.config.test.tsx',
-    '^@src/(.*)$': '<rootDir>/src/$1',
   },
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {

--- a/shell/jest.config.js
+++ b/shell/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/file.js',
     '\\.(css|scss)$': require.resolve('identity-obj-proxy'),
     'site.config': '<rootDir>/site.config.test.tsx',
-    '^@src/(.*)$': '<rootDir>/src/$1',
   },
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {

--- a/tools/jest/jest.config.js
+++ b/tools/jest/jest.config.js
@@ -9,7 +9,6 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|scss)$': require.resolve('identity-obj-proxy'),
     'site.config': path.resolve(process.cwd(), './site.config.test.tsx'),
-    '^@src/(.*)$': '<rootDir>/src/$1',
   },
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',


### PR DESCRIPTION
The @src alias should be defined by individual apps.  Plus we're not
using the alias in frontend-base itself (yet?).
