### PR TITLE
fix: default publicPath to '/' instead of 'auto'

### DIFF
--- a/tools/webpack/common-config/dev/getDevServer.ts
+++ b/tools/webpack/common-config/dev/getDevServer.ts
@@ -9,10 +9,8 @@ export default function getDevServer(): Configuration {
     headers: {
       'Access-Control-Allow-Origin': '*',
     },
-    // For obvious reasons, 'auto' won't work for publicPath here, so we
-    // force '/' unless PUBLIC_PATH is set.
     historyApiFallback: {
-      index: path.join(getPublicPath('/'), 'index.html'),
+      index: path.join(getPublicPath(), 'index.html'),
       disableDotRule: true,
     },
     host: 'apps.local.openedx.io',

--- a/tools/webpack/utils/getPublicPath.ts
+++ b/tools/webpack/utils/getPublicPath.ts
@@ -1,3 +1,3 @@
-export default function getPublicPath(defaultPath = 'auto') {
+export default function getPublicPath(defaultPath = '/') {
   return process.env.PUBLIC_PATH ?? defaultPath;
 }


### PR DESCRIPTION
### Description

With 'auto', webpack generates relative asset URLs. When the dev server or production serve command returns index.html for SPA sub-paths (e.g. /authn/login), the browser resolves those relative URLs against the sub-path instead of the root, causing assets to 404 or be served as HTML.

Closes #188

### To test

If you care to test this, just run the latest frontend-base branches of the apps via frontend-template-site.  Without this patch, you need to add a `PUBLIC_PATH=/` to the `npm run dev` script in template-site's package.json, otherwise loading resources (in particular, the CSS in Authn) will fail.