### PR TITLE
feat: simplify i18n extraction to output flat KV directly

### DIFF
--- a/tools/cli/openedx.ts
+++ b/tools/cli/openedx.ts
@@ -68,7 +68,7 @@ switch (commandName) {
       '--format', path.resolve(__dirname, './utils/formatter.js'),
       '--ignore', `${srcFoldersString}/**/*.json`,
       '--ignore', `${srcFoldersString}/**/*.d.ts`,
-      '--out-file', './temp/formatjs/Default.messages.json',
+      '--out-file', './src/i18n/transifex_input.json',
       '--', `${srcFoldersString}/**/*.{j,t}s*`,
     ]);
     require('@formatjs/cli/bin/formatjs');

--- a/tools/cli/utils/formatter.ts
+++ b/tools/cli/utils/formatter.ts
@@ -1,10 +1,3 @@
-exports.format = (messages: Record<string, { defaultMessage: string, description: string }>) => {
-  const results = Object.entries(messages).map(([id, message]) => (
-    {
-      id,
-      defaultMessage: message.defaultMessage,
-      description: message.description,
-    }
-  ));
-  return results;
-};
+exports.format = (messages: Record<string, { defaultMessage: string, description: string }>) => Object.fromEntries(
+  Object.entries(messages).map(([id, { defaultMessage }]) => [id, defaultMessage]),
+);


### PR DESCRIPTION
## Summary

- Update `formatter.ts` to output flat `{"key": "value"}` JSON instead of an array of `{id, defaultMessage, description}` objects
- Update `openedx.ts` to write directly to `src/i18n/transifex_input.json`, removing the need for a separate concat step
- Matches the flat KV format expected by openedx-translations and used by all other frontend repos

This follows the pattern established in [openedx/paragon#4177](https://github.com/openedx/paragon/pull/4177) and unblocks `make extract_translations` on frontend-base MFE branches (e.g. frontend-app-authn's `frontend-base` branch), which don't have access to `frontend-platform` or `frontend-build`.

Verified by installing a local tarball of `frontend-base` in `frontend-app-authn` (on its `frontend-base` branch) and confirming `npm run i18n_extract` successfully writes flat KV to `src/i18n/transifex_input.json`.

## Test plan

- [ ] Run `make extract_translations` in an MFE on a `frontend-base` branch and verify `src/i18n/transifex_input.json` is created in flat KV format

<details>
<summary><h3>Log</h3></summary>

# extract-translations work log

**Repo:** `frontend-app-authn` — branch `extract-translations` (off `frontend-base`)

**Goal:** Get `make extract_translations` working on the `frontend-base` branch, using the pattern established in [openedx/paragon#4177](https://github.com/openedx/paragon/pull/4177).

## Background

Standard MFEs use a two-step pipeline via `make extract_translations`:
1. `i18n.extract` — runs `fedx-scripts formatjs extract` (from `frontend-build`), outputs an array of `{id, defaultMessage, description}` objects to `./temp/babel-plugin-formatjs/Default.messages.json`
2. `i18n.concat` — runs `transifex-utils.js` (from `frontend-platform`), reads that array and writes flat KV to `src/i18n/transifex_input.json`

The `frontend-base` branch doesn't have `frontend-platform` or `frontend-build` available, so this pipeline breaks.

## Pattern (from paragon#4177)

- Add `src/i18n/transifex-formatter.js` — a small custom formatter that outputs flat KV JSON
- Update the `i18n_extract` script in `package.json` to use `--format ./src/i18n/transifex-formatter.js`

## Error (current)

`make extract_translations` fails at the `i18n.concat` step:

```
Error: Found no messages
    at Object.<anonymous> (.../node_modules/@openedx/frontend-base/dist/tools/cli/transifex-utils.js:38:11)
```

The `i18n.extract` step runs `openedx formatjs extract` (from `@openedx/frontend-base`'s CLI) but doesn't write anything to `./temp/babel-plugin-formatjs` in the format `transifex-utils.js` expects, causing the concat step to throw.

## Investigation findings

- `i18n_extract` in `package.json` runs `openedx formatjs extract` (from `@openedx/frontend-base` CLI)
- That command uses `frontend-base`'s own `formatter.js` and writes an array of `{id, defaultMessage, description}` objects to `./temp/formatjs/Default.messages.json`
- The Makefile's `i18n.concat` step passes `./temp/babel-plugin-formatjs` to `transifex-utils.js` — that directory never gets created, so it throws `Found no messages`
- **Root cause: path mismatch** — the Makefile still references the old `frontend-build`-era path `./temp/babel-plugin-formatjs`, but `frontend-base`'s CLI writes to `./temp/formatjs`

The fix from paragon#4177 sidesteps this entirely — use a custom formatter that outputs flat KV directly, removing the need for the concat step altogether.

## Setup done in authn (`extract-translations` branch)

- Installed `@openedx/frontend-dev-utils` as a dev dependency
- Added `dev:autoinstall` script: `PORT=1999 PUBLIC_PATH=/authn FRONTEND_BASE_DIR=../frontend-base devutils-dev-with-autoinstall`
- `pack:watch` running in `frontend-base` (`simplify-i18n-extract` branch)
- `dev:autoinstall` running in authn — picks up pack changes from `frontend-base` automatically

## Steps

- [x] Verify `make extract_translations` is currently broken (confirmed same error with latest autoinstalled `frontend-base`)
- [x] Fix in `frontend-base` (`simplify-i18n-extract` branch): updated `formatter.ts` to output flat KV, updated `openedx.ts` to write directly to `src/i18n/transifex_input.json`
- [x] Updated authn's Makefile: removed `i18n.concat` step, removed unused `transifex_utils`/`transifex_temp`/`transifex_input` variables, simplified `extract_translations` target
- [x] Verified `npm run i18n_extract` writes flat KV to `src/i18n/transifex_input.json`

## Note on testing

`make extract_translations` runs `npm ci` (via `requirements`) which reinstalls from the registry, wiping out the local pack. During dev, use `npm run i18n_extract` directly after `dev:autoinstall` has installed the local pack. The full `make extract_translations` will work correctly once the `frontend-base` changes are published.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)