### PR TITLE
build: add semantic-release (dry-run)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release CI
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: write  # For Semantic Release tagging
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Release to npm/Github
+        run: npx semantic-release@25 --dry-run
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,13 @@
+{
+  "branches": [
+    "placeholder",
+    { "name": "main", "prerelease": "alpha", "channel": "latest" }
+  ],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `.releaserc` configuring `main` as a prerelease (`alpha`) branch publishing to the `latest` dist-tag, with `placeholder` as the required stable branch anchor
- Add `.github/workflows/release.yml` triggered on push to `main`, using OIDC for npm publishing and `OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN` for GitHub releases
- Running with `--dry-run` to verify the setup works correctly on CI. A follow-up PR will remove the flag to enable actual releases.

## Notes

The `placeholder` branch must exist on the repo before this workflow runs. The `refs/notes/semantic-release` git note pointing to the commit at `v1.0.0-alpha.14` with `{"channels":["latest"]}` must also be present — see [issue #174](https://github.com/openedx/frontend-base/issues/174) for details on that setup.

<details>
<summary><h3>Log</h3></summary>

# frontend-base Semantic Release Setup - Work Log

**Date:** 2026-03-25

**Objective:** Add semantic-release to `@openedx/frontend-base` and open a PR to the upstream `openedx/frontend-base`.

## References

- [Issue #174](https://github.com/openedx/frontend-base/issues/174) — prior dry-run work log
- [frontend-dev-utils PR #6](https://github.com/openedx/frontend-dev-utils/pull/6) — workflow + .releaserc pattern (dry-run)
- [frontend-dev-utils PR #9](https://github.com/openedx/frontend-dev-utils/pull/9) — removed --dry-run to enable real publishing

## Repo Setup

- Cloned fork `brian-smith-tcril/frontend-base` into `/home/bsmith/code/claude/semantic-release-base`
- Added `upstream` remote pointing to `https://github.com/openedx/frontend-base.git` (HTTPS, no accidental pushes)
- Current version in `package.json`: `1.0.0-alpha.14`
- `publishConfig.access: "public"` already set

## Key Context from Prior Work (Issue #174)

- Tags exist: `v1.0.0-alpha.0` through `v1.0.0-alpha.13`; `v1.0.0-alpha.14` presumably added since
- A `placeholder` branch is required as a stable branch for semantic-release (since `main` is a prerelease branch)
- Git notes at `refs/notes/semantic-release` track channel info; added to the commit at `v1.0.0-alpha.13^{}` with `{"channels":["latest"]}`
- `main` publishes to `latest` dist-tag with `prerelease: "alpha"`

## .releaserc

Based on issue #174 dry-run config (with `repositoryUrl` removed — let it be inferred from the git remote):

```json
{
  "branches": [
    "placeholder",
    { "name": "main", "prerelease": "alpha", "channel": "latest" }
  ],
  "tagFormat": "v${version}",
  "plugins": [
    "@semantic-release/commit-analyzer",
    "@semantic-release/release-notes-generator",
    "@semantic-release/npm",
    "@semantic-release/github"
  ]
}
```

## Workflow

Based on `frontend-dev-utils` `.github/workflows/release.yml` (OIDC for npm, no NPM_TOKEN needed):
- Trigger on push to `main`
- `permissions: id-token: write, contents: write`
- `actions/checkout@v6` with `fetch-depth: 0`
- `actions/setup-node@v6` with `node-version-file: '.nvmrc'`
- `npm ci` then `npx semantic-release@25 --dry-run`
- `GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}`

Note: used v6 for both actions (latest major as of 2026-03-25); `frontend-dev-utils` was on v4.

## Session Progress

- [x] Create branch `add-semantic-release` (no prefix — working on fork)
- [x] Add `.releaserc`
- [x] Add `.github/workflows/release.yml` (with `--dry-run`)
- [x] Commit: `7dec66e2` — "build: add semantic-release (dry-run)"
- [x] Push branch to fork (`git@github.com:brian-smith-tcril/frontend-base.git`)
- [x] Open PR to `openedx/frontend-base`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)