### PR TITLE
build: Unpin react-focus-on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "postcss-rtlcss": "^5.5.0",
         "prop-types": "^15.8.1",
         "react-dev-utils": "12.0.1",
-        "react-focus-on": "<3.10.0",
+        "react-focus-on": "^3.10.2",
         "react-intl": "^6.6.6",
         "react-refresh": "0.16.0",
         "react-refresh-typescript": "^2.0.9",
@@ -16902,24 +16902,24 @@
       }
     },
     "node_modules/react-focus-on": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.9.4.tgz",
-      "integrity": "sha512-NFKmeH6++wu8e7LJcbwV8TTd4L5w/U5LMXTMOdUcXhCcZ7F5VOvgeTHd4XN1PD7TNmdvldDu/ENROOykUQ4yQg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.10.2.tgz",
+      "integrity": "sha512-Ytdx2dh6yoCc2HI4Y7u5bI1xF1oeeRud52v8zQdGsyxyVC5W/dwcgQGp+CCpoLGQegwKHybH8diVj+Qn23y+hA==",
       "license": "MIT",
       "dependencies": {
-        "aria-hidden": "^1.2.2",
-        "react-focus-lock": "^2.11.3",
-        "react-remove-scroll": "^2.6.0",
-        "react-style-singleton": "^2.2.1",
+        "aria-hidden": "^1.2.5",
+        "react-focus-lock": "^2.13.7",
+        "react-remove-scroll": "^2.6.4",
+        "react-style-singleton": "^2.2.3",
         "tslib": "^2.3.1",
-        "use-sidecar": "^1.1.2"
+        "use-sidecar": "^1.1.3"
       },
       "engines": {
         "node": ">=8.5.0"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "postcss-rtlcss": "^5.5.0",
     "prop-types": "^15.8.1",
     "react-dev-utils": "12.0.1",
-    "react-focus-on": "<3.10.0",
+    "react-focus-on": "^3.10.2",
     "react-intl": "^6.6.6",
     "react-refresh": "0.16.0",
     "react-refresh-typescript": "^2.0.9",


### PR DESCRIPTION
Since 90ca7aa3 was merged, the upstream issue with the 3.10 series was
fixed:

https://github.com/theKashey/react-focus-on/issues/111#issuecomment-3768251534
