### PR TITLE
fix: make `extract_translations` makefile target work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
 # Documentation CLI usage: https://github.com/documentationjs/documentation/blob/master/docs/USAGE.md
 
 i18n = ./src/i18n
-transifex_input = $(i18n)/transifex_input.json
-transifex_utils = $(i18n)/scripts/transifex-utils.js
 
-# This directory must match .babelrc .
-transifex_temp = ./temp/babel-plugin-formatjs
 
 doc_command = ./node_modules/.bin/documentation build src -g -c ./docs/documentation.config.yml -f md -o ./docs/_API-body.md --sort-order alpha
 cat_docs_command = cat ./docs/_API-header.md ./docs/_API-body.md > ./docs/API.md
@@ -37,13 +33,5 @@ docs-lint:
 requirements:  ## install ci requirements
 	npm ci
 
-i18n.extract:
-	# Pulling display strings from .jsx files into .json files...
-	rm -rf $(transifex_temp)
-	npm run-script i18n_extract
-
-i18n.concat:
-	# Gathering JSON messages into one file...
-	$(transifex_utils) $(transifex_temp) $(transifex_input)
-
-extract_translations: | requirements i18n.extract i18n.concat
+extract_translations: | requirements
+	npm run i18n_extract

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test": "jest",
     "watch:build": "nodemon --exec 'npm run build'",
     "watch:docs": "nodemon --watch docs/template --watch README.md --exec npm run docs",
-    "watch:pack": "nodemon --exec 'npm run pack'"
+    "watch:pack": "nodemon --exec 'npm run pack'",
+    "i18n_extract": "npm run build && node ./dist/tools/cli/openedx.js formatjs extract --include=shell"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this updates the `extract_translations` target to extract messages from `shell`, using the updated extraction flow from https://github.com/openedx/frontend-base/pull/200

* Part of https://github.com/openedx/frontend-base/issues/176