### PR TITLE
docs: add ATLAS_OPTIONS to pull_translations example in migration guide

### DIFF
--- a/docs/how_tos/migrate-frontend-app.md
+++ b/docs/how_tos/migrate-frontend-app.md
@@ -561,7 +561,7 @@ And update your `pull_translations` Makefile target to use it:
 
 ```Makefile
 pull_translations: | requirements
-	npm run translations:pull
+	npm run translations:pull -- --atlas-options="$(ATLAS_OPTIONS)"
 ```
 
 Running `npm run translations:pull` will pull translations from `openedx-translations` and generate `src/i18n/messages.ts`.


### PR DESCRIPTION
Small fix to the migration guide — the `pull_translations` Makefile example was missing the `ATLAS_OPTIONS` pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)