### PR TITLE
feat: add React Query devtools to the shell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@formatjs/ts-transformer": "^3.13.14",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
         "@stylistic/eslint-plugin": "^2.9.0",
+        "@tanstack/react-query-devtools": "^5.99.0",
         "@types/eslint__js": "^8.42.3",
         "@types/gradient-string": "^1.1.6",
         "@types/lodash.keyby": "^4.6.9",
@@ -5038,9 +5039,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.96.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
-      "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -5048,20 +5049,47 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
+      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
-      "version": "5.96.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.2.tgz",
-      "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.96.2"
+        "@tanstack/query-core": "5.99.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
+      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.99.0",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@formatjs/ts-transformer": "^3.13.14",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
     "@stylistic/eslint-plugin": "^2.9.0",
+    "@tanstack/react-query-devtools": "^5.99.0",
     "@types/eslint__js": "^8.42.3",
     "@types/gradient-string": "^1.1.6",
     "@types/lodash.keyby": "^4.6.9",

--- a/shell/site.tsx
+++ b/shell/site.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react';
+import { lazy, StrictMode, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -13,6 +13,18 @@ import { addAppConfigs } from '../runtime/config';
 import messages from 'site.i18n';
 import createRouter from './router/createRouter';
 
+/*
+ * Use a dynamic import guarded by process.env.NODE_ENV so that webpack
+ * places the devtools in a separate async chunk that is only requested
+ * in development. In production the ternary resolves to null and the
+ * chunk is never loaded.
+ */
+const ReactQueryDevtools = process.env.NODE_ENV === 'development'
+  ? lazy(() => import('@tanstack/react-query-devtools')
+    .then((m) => ({ default: m.ReactQueryDevtools }))
+    .catch(() => ({ default: () => null })))
+  : null;
+
 subscribe(SITE_READY, async () => {
   const queryClient = new QueryClient();
   const router = createRouter();
@@ -24,6 +36,11 @@ subscribe(SITE_READY, async () => {
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <RouterProvider router={router} />
+        {ReactQueryDevtools && (
+          <Suspense fallback={null}>
+            <ReactQueryDevtools initialIsOpen={false} />
+          </Suspense>
+        )}
       </QueryClientProvider>
     </StrictMode>
   );


### PR DESCRIPTION
### Description

`shell/site.tsx` already owns the top-level `QueryClient` and `QueryClientProvider`, making it the natural place for React Query devtools. This adds `@tanstack/react-query-devtools` as a direct dependency and renders it inside the shell's `QueryClientProvider`, guarded by `process.env.NODE_ENV === 'development'` so it's excluded from production bundles.

With devtools centralized in the shell, individual apps no longer need to add them separately.

Closes #206

### LLM usage notice

Built with assistance from Claude.