### PR TITLE
feat: header parity with frontend-component-header

### DIFF
--- a/docs/how_tos/migrate-frontend-app.md
+++ b/docs/how_tos/migrate-frontend-app.md
@@ -725,7 +725,7 @@ const app: App = {
     id: 'example.page',
     Component: ExamplePage,
     handle: {
-      role: 'example'
+      roles: ['example']
     }
   }],
 };
@@ -835,7 +835,7 @@ const siteConfig: SiteConfig = {
         <div>Test App 1</div>
       ),
       handle: {
-        role: 'test-app-1'
+        roles: ['test-app-1']
       }
     }]
   }],

--- a/runtime/react/hooks/useActiveRouteRoleWatcher.ts
+++ b/runtime/react/hooks/useActiveRouteRoleWatcher.ts
@@ -14,8 +14,10 @@ const useActiveRouteRoleWatcher = () => {
     // Route roles
     for (const match of matches) {
       if (isRoleRouteObject(match)) {
-        if (!roles.includes(match.handle.role)) {
-          roles.push(match.handle.role);
+        for (const role of match.handle.roles) {
+          if (!roles.includes(role)) {
+            roles.push(role);
+          }
         }
       }
     }

--- a/runtime/routing/utils.test.ts
+++ b/runtime/routing/utils.test.ts
@@ -12,7 +12,7 @@ describe('getUrlByRouteRole', () => {
         appId: 'test-app',
         routes: [{
           path: '/app1',
-          handle: { role: 'test-app-1' },
+          handle: { roles: ['test-app-1'] },
         }],
       }],
     } as any);
@@ -29,7 +29,7 @@ describe('getUrlByRouteRole', () => {
           children: [
             {
               path: 'login',
-              handle: { role: 'org.openedx.frontend.role.login' },
+              handle: { roles: ['org.openedx.frontend.role.login'] },
             },
           ],
         }],

--- a/runtime/routing/utils.ts
+++ b/runtime/routing/utils.ts
@@ -8,7 +8,7 @@ function findRoleInRoutes(routes: RouteObject[], role: string, prefix = ''): str
     const segment = route.path ?? '';
     const fullPath = segment.startsWith('/') ? segment : `${prefix}/${segment}`.replace(/\/+/g, '/');
 
-    if (route.handle?.role === role) {
+    if (route.handle?.roles?.includes(role)) {
       return fullPath || null;
     }
 
@@ -48,5 +48,5 @@ export function getUrlByRouteRole(role: string) {
 }
 
 export function isRoleRouteObject(match: RouteObject): match is RoleRouteObject {
-  return match.handle !== undefined && 'role' in match.handle;
+  return match.handle !== undefined && 'roles' in match.handle;
 }

--- a/shell/Logo.test.tsx
+++ b/shell/Logo.test.tsx
@@ -16,31 +16,31 @@ describe('Logo component', () => {
     setSiteConfig(originalConfig);
   });
 
-  it('renders the image with default URL when no imageUrl prop is provided and headerLogoImageUrl is not set in site config', async () => {
-    const { getByRole, queryByRole } = render(<Logo />);
+  it('renders the image with default URL and links to / when no props are provided', async () => {
+    const { getByRole } = render(<Logo />);
     const image = getByRole('img');
     expect(image).toHaveAttribute('src', 'https://edx-cdn.org/v3/default/logo.svg');
-    const link = queryByRole('link');
-    expect(link).toBeNull();
+    const link = getByRole('link');
+    expect(link).toHaveAttribute('href', '/');
   });
 
-  it('renders the image with provided imageUrl', async () => {
+  it('renders the image with provided imageUrl and links to / by default', async () => {
     const testUrl = 'https://example.com/test-logo.svg';
-    const { getByRole, queryByRole } = render(<Logo imageUrl={testUrl} />);
+    const { getByRole } = render(<Logo imageUrl={testUrl} />);
     const image = getByRole('img');
     expect(image).toHaveAttribute('src', testUrl);
-    const link = queryByRole('link');
-    expect(link).toBeNull();
+    const link = getByRole('link');
+    expect(link).toHaveAttribute('href', '/');
   });
 
-  it('renders the image with headerLogoImageUrl when set in site config and no imageUrl prop is provided', async () => {
+  it('renders the image with headerLogoImageUrl when set in site config', async () => {
     const configLogoUrl = 'https://example.com/config-logo.svg';
     mergeSiteConfig({ headerLogoImageUrl: configLogoUrl });
-    const { getByRole, queryByRole } = render(<Logo />);
+    const { getByRole } = render(<Logo />);
     const image = getByRole('img');
     expect(image).toHaveAttribute('src', configLogoUrl);
-    const link = queryByRole('link');
-    expect(link).toBeNull();
+    const link = getByRole('link');
+    expect(link).toHaveAttribute('href', '/');
   });
 
   it('renders the image wrapped in a Hyperlink when destinationUrl is provided', async () => {

--- a/shell/Logo.tsx
+++ b/shell/Logo.tsx
@@ -1,6 +1,8 @@
 import { IntlProvider } from 'react-intl';
 import { Hyperlink, Image } from '@openedx/paragon';
 import { getSiteConfig } from '../runtime/config';
+import { getUrlByRouteRole } from '../runtime/routing';
+import { homeRole } from './constants';
 
 interface LogoProps {
   imageUrl?: string,
@@ -9,7 +11,7 @@ interface LogoProps {
 
 export default function Logo({
   imageUrl = getSiteConfig().headerLogoImageUrl ?? 'https://edx-cdn.org/v3/default/logo.svg',
-  destinationUrl
+  destinationUrl = getUrlByRouteRole(homeRole) || '/'
 }: LogoProps) {
   const image = (
     <Image src={imageUrl} style={{ maxHeight: '2rem' }} />

--- a/shell/constants.ts
+++ b/shell/constants.ts
@@ -1,1 +1,2 @@
+export const homeRole = 'org.openedx.frontend.role.home';
 export const providesChromelessRolesId = 'org.openedx.frontend.provides.chromelessRoles.v1';

--- a/shell/dev/devHome/HomePage.tsx
+++ b/shell/dev/devHome/HomePage.tsx
@@ -1,3 +1,4 @@
+import { Container } from '@openedx/paragon';
 import { Link } from 'react-router-dom';
 import { useIntl } from '../../../runtime';
 import { getUrlByRouteRole } from '../../../runtime/routing';
@@ -10,7 +11,7 @@ export default function HomePage() {
   const intl = useIntl();
 
   return (
-    <div className="p-3">
+    <Container fluid size="xl">
       <p>{intl.formatMessage(messages.homeContent)}</p>
       <ul>
         {coursewareUrl !== null && (
@@ -23,6 +24,6 @@ export default function HomePage() {
           <li><Link to={slotShowcaseUrl}>Go to slot showcase page</Link></li>
         )}
       </ul>
-    </div>
+    </Container>
   );
 }

--- a/shell/dev/devHome/app.ts
+++ b/shell/dev/devHome/app.ts
@@ -1,14 +1,15 @@
 import { App } from '../../../types';
+import { homeRole } from '../../constants';
 import HomePage from './HomePage';
 
 const app: App = {
   appId: 'org.openedx.frontend.app.dev.home',
   routes: [{
-    path: '/',
+    path: '/dev',
     id: 'org.openedx.frontend.route.dev.home',
     Component: HomePage,
     handle: {
-      role: 'org.openedx.frontend.role.devHome'
+      roles: [homeRole],
     }
   }],
 };

--- a/shell/dev/slotShowcase/SlotShowcasePage.tsx
+++ b/shell/dev/slotShowcase/SlotShowcasePage.tsx
@@ -27,7 +27,7 @@ function Section({ title, children }: { title: string, children: ReactNode }) {
 
 export default function SlotShowcasePage() {
   return (
-    <Container size="xl" className="showcase-page py-4">
+    <Container fluid size="xl" className="showcase-page py-4">
       <div className="showcase-full-width">
         <h1>Slot Showcase</h1>
         <p>As a best practice, widgets should pass additional props (<code>...props</code>) to their rendered HTMLElement.  This allows custom layouts to add <code>className</code> and <code>style</code> props as necessary for the layout.</p>

--- a/shell/header/AuthenticatedMenu.tsx
+++ b/shell/header/AuthenticatedMenu.tsx
@@ -1,5 +1,4 @@
-import { DropdownButton } from '@openedx/paragon';
-import { Person } from '@openedx/paragon/icons';
+import { AvatarButton, Dropdown } from '@openedx/paragon';
 
 import {
   Slot,
@@ -15,16 +14,19 @@ export default function AuthenticatedMenu({ className }: AuthenticatedMenuProps)
 
   const displayUserName = authenticatedUser?.name || authenticatedUser?.username;
 
-  const title = (
-    <div className="d-flex mr-2 align-items-center gap-2">
-      <Person />
-      {displayUserName}
-    </div>
-  );
-
   return (
-    <DropdownButton size="sm" id="user-nav-dropdown" title={title} variant="outline-primary" className={className}>
-      <Slot id="org.openedx.frontend.slot.header.authenticatedMenu.v1" />
-    </DropdownButton>
+    <Dropdown className={className}>
+      <Dropdown.Toggle
+        as={AvatarButton}
+        id="user-nav-dropdown"
+        variant="outline-primary"
+        src={authenticatedUser?.avatar}
+      >
+        {displayUserName}
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
+        <Slot id="org.openedx.frontend.slot.header.authenticatedMenu.v1" />
+      </Dropdown.Menu>
+    </Dropdown>
   );
 }

--- a/shell/header/Header.tsx
+++ b/shell/header/Header.tsx
@@ -7,8 +7,8 @@ export default function Header() {
 
   return (
     <>
-      <header className="border-bottom py-2">
-        <nav className="py-2">
+      <header className="border-bottom">
+        <nav>
           <a className="sr-only sr-only-focusable" href="#main-content">{intl.formatMessage(messages.skipNavLink)}</a>
           <Slot id="org.openedx.frontend.slot.header.desktop.v1" />
           <Slot id="org.openedx.frontend.slot.header.mobile.v1" />

--- a/shell/header/app.scss
+++ b/shell/header/app.scss
@@ -1,0 +1,10 @@
+header {
+  .nav-link {
+    padding: 1.125rem 1rem;
+
+    &.active {
+      background: var(--pgn-color-bg-active, #0A3055);
+      color: var(--pgn-color-active, #fff);
+    }
+  }
+}

--- a/shell/header/app.tsx
+++ b/shell/header/app.tsx
@@ -15,6 +15,7 @@ import messages from '../Shell.messages';
 import CourseTabsNavigation from './course-navigation-bar/CourseTabsNavigation';
 import { isCourseNavigationRoute } from './course-navigation-bar/utils';
 import { appId } from './constants';
+import './app.scss';
 
 const config: App = {
   appId,

--- a/shell/header/desktop/DesktopLayout.tsx
+++ b/shell/header/desktop/DesktopLayout.tsx
@@ -1,3 +1,4 @@
+import { Container } from '@openedx/paragon';
 import classNames from 'classnames';
 import { useMediaQuery } from 'react-responsive';
 import { Slot } from '../../../runtime';
@@ -6,10 +7,13 @@ export default function DesktopLayout() {
   const isMobile = useMediaQuery({ maxWidth: 768 });
 
   return (
-    <div className={classNames(
-      'align-items-center justify-content-between px-3',
-      isMobile ? 'd-none' : 'd-flex'
-    )}
+    <Container
+      fluid
+      size="xl"
+      className={classNames(
+        'align-items-center justify-content-between',
+        isMobile ? 'd-none' : 'd-flex'
+      )}
     >
       <div className="d-flex flex-grow-1 align-items-center">
         <Slot id="org.openedx.frontend.slot.header.desktopLeft.v1" />
@@ -17,6 +21,6 @@ export default function DesktopLayout() {
       <div className="d-flex align-items-center">
         <Slot id="org.openedx.frontend.slot.header.desktopRight.v1" />
       </div>
-    </div>
+    </Container>
   );
 }

--- a/shell/header/desktop/PrimaryNavLinks.tsx
+++ b/shell/header/desktop/PrimaryNavLinks.tsx
@@ -3,7 +3,7 @@ import { Slot } from '../../../runtime';
 
 export default function PrimaryNavLinks() {
   return (
-    <Nav className="flex-nowrap align-items-center">
+    <Nav className="flex-nowrap align-items-center ml-3">
       <Slot id="org.openedx.frontend.slot.header.primaryLinks.v1" />
     </Nav>
   );

--- a/shell/header/mobile/MobileLayout.tsx
+++ b/shell/header/mobile/MobileLayout.tsx
@@ -1,4 +1,4 @@
-import { Button, Nav } from '@openedx/paragon';
+import { Button, Container, Nav } from '@openedx/paragon';
 import { MenuIcon } from '@openedx/paragon/icons';
 import classNames from 'classnames';
 import { useCallback, useState } from 'react';
@@ -16,9 +16,11 @@ export default function MobileLayout() {
 
   return (
     <>
-      <div
+      <Container
+        fluid
+        size="xl"
         className={classNames(
-          'align-items-center justify-content-between pr-3 booyah',
+          'align-items-center justify-content-between',
           isMobile ? 'd-flex' : 'd-none',
         )}
       >
@@ -34,7 +36,7 @@ export default function MobileLayout() {
         <div className="d-flex flex-grow-1 flex-basis-0 justify-content-end align-items-center">
           <Slot id="org.openedx.frontend.slot.header.mobileRight.v1" />
         </div>
-      </div>
+      </Container>
       {mobileOpen && (
         <FocusOn onClickOutside={() => setMobileOpen(false)} onEscapeKey={() => setMobileOpen(false)}>
           <Nav className="flex-column">

--- a/shell/index.ts
+++ b/shell/index.ts
@@ -3,6 +3,6 @@ export { default as DefaultMain } from './DefaultMain';
 export { default as shellApp } from './app';
 export { Footer, footerApp } from './footer';
 export { providesCourseNavigationRolesId, Header, headerApp } from './header';
-export { providesChromelessRolesId } from './constants';
+export { homeRole, providesChromelessRolesId } from './constants';
 export { default as LinkMenuItem } from './menus/LinkMenuItem';
 export { default as NavDropdownMenuSlot } from './menus/NavDropdownMenuSlot';

--- a/shell/menus/LinkMenuItem.tsx
+++ b/shell/menus/LinkMenuItem.tsx
@@ -1,5 +1,6 @@
 import { Dropdown, Hyperlink, NavDropdown, NavLink } from '@openedx/paragon';
 import { useIntl } from 'react-intl';
+import { useLocation } from 'react-router-dom';
 
 import { getUrlByRouteRole } from '../../runtime/routing';
 import {
@@ -18,6 +19,7 @@ interface LinkMenuItemProps {
 
 export default function LinkMenuItem({ label, role, url, variant = 'hyperlink' }: LinkMenuItemProps) {
   const intl = useIntl();
+  const location = useLocation();
   const finalLabel = getItemLabel(label, intl);
 
   let finalUrl: string | null | undefined;
@@ -41,7 +43,7 @@ export default function LinkMenuItem({ label, role, url, variant = 'hyperlink' }
     );
   } else if (variant === 'navLink') {
     return (
-      <NavLink href={finalUrl}>
+      <NavLink href={finalUrl} active={location.pathname.replace(/\/$/, '') === finalUrl.replace(/\/$/, '')}>
         {finalLabel}
       </NavLink>
     );

--- a/shell/router/getAppRoutes.test.tsx
+++ b/shell/router/getAppRoutes.test.tsx
@@ -1,9 +1,10 @@
 import { RouteObject } from 'react-router';
-import { getSiteConfig } from '../../runtime';
+import { getSiteConfig, getUrlByRouteRole } from '../../runtime';
 import getAppRoutes from './getAppRoutes';
 
 jest.mock('../../runtime', () => ({
   getSiteConfig: jest.fn(),
+  getUrlByRouteRole: jest.fn(),
 }));
 
 describe('getAppRoutes', () => {
@@ -39,6 +40,42 @@ describe('getAppRoutes', () => {
       { path: '/page2', element: <div>Page 2</div> },
       { path: '/page3', element: <div>Page 3</div> }
     ]);
+  });
+
+  it('should append a / redirect when the home role is claimed', () => {
+    const mockApps = [
+      {
+        routes: [
+          { path: '/home', handle: { roles: ['org.openedx.frontend.role.home'] } },
+        ]
+      },
+    ];
+
+    (getSiteConfig as jest.Mock).mockReturnValue({ apps: mockApps });
+    (getUrlByRouteRole as jest.Mock).mockReturnValue('/home');
+
+    const routes = getAppRoutes();
+
+    expect(routes).toHaveLength(2);
+    expect(routes[1].path).toBe('/');
+  });
+
+  it('should not append a / redirect when no home role is claimed', () => {
+    const mockApps = [
+      {
+        routes: [
+          { path: '/page1', element: <div>Page 1</div> },
+        ]
+      },
+    ];
+
+    (getSiteConfig as jest.Mock).mockReturnValue({ apps: mockApps });
+    (getUrlByRouteRole as jest.Mock).mockReturnValue(null);
+
+    const routes = getAppRoutes();
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0].path).toBe('/page1');
   });
 
   it('should ignore apps without routes', () => {

--- a/shell/router/getAppRoutes.ts
+++ b/shell/router/getAppRoutes.ts
@@ -1,7 +1,8 @@
-import { RouteObject } from 'react-router';
+import { redirect, RouteObject } from 'react-router';
 
-import { getSiteConfig } from '../../runtime';
+import { getSiteConfig, getUrlByRouteRole } from '../../runtime';
 import { App } from '../../types';
+import { homeRole } from '../constants';
 
 export default function getAppRoutes() {
   const { apps } = getSiteConfig();
@@ -17,5 +18,18 @@ export default function getAppRoutes() {
       }
     );
   }
+
+  /*
+   * If any app claims the home role, append a redirect from / to that URL.
+   * Appended last so that an app with its own / route takes priority.
+   */
+  const homeUrl = getUrlByRouteRole(homeRole);
+  if (homeUrl) {
+    routes.push({
+      path: '/',
+      loader: () => redirect(homeUrl),
+    });
+  }
+
   return routes;
 }

--- a/shell/site.tsx
+++ b/shell/site.tsx
@@ -21,8 +21,8 @@ import createRouter from './router/createRouter';
  */
 const ReactQueryDevtools = process.env.NODE_ENV === 'development'
   ? lazy(() => import('@tanstack/react-query-devtools')
-    .then((m) => ({ default: m.ReactQueryDevtools }))
-    .catch(() => ({ default: () => null })))
+      .then((m) => ({ default: m.ReactQueryDevtools }))
+      .catch(() => ({ default: () => null })))
   : null;
 
 subscribe(SITE_READY, async () => {

--- a/test-site/src/authenticated-page/AuthenticatedPage.tsx
+++ b/test-site/src/authenticated-page/AuthenticatedPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 
 import { useAuthenticatedUser, useSiteConfig } from '@openedx/frontend-base';
+import { Container } from '@openedx/paragon';
 import { FormattedMessage } from 'react-intl';
 
 export default function AuthenticatedPage() {
@@ -8,11 +9,11 @@ export default function AuthenticatedPage() {
   const config = useSiteConfig();
 
   return (
-    <main className="p-3">
+    <Container fluid size="xl">
       <h1>{config.siteName} authenticated page.</h1>
       <FormattedMessage id="authenticated.page.content" defaultMessage="This is a localized message.  Try it in French." description="This is a test message to prove localization works." />
       <p>{authenticatedUser === null ? 'You are not authenticated.' : `Hi there, ${authenticatedUser.username}.`}</p>
       <p>Visit <Link to="/">public page</Link>.</p>
-    </main>
+    </Container>
   );
 }

--- a/test-site/src/example-page/ExamplePage.tsx
+++ b/test-site/src/example-page/ExamplePage.tsx
@@ -29,7 +29,7 @@ export default function ExamplePage() {
   }, []);
 
   return (
-    <Container>
+    <Container fluid size="xl">
       <h1>{config.siteName} test page</h1>
 
       <h2>Links</h2>

--- a/types.ts
+++ b/types.ts
@@ -13,9 +13,9 @@ export interface ExternalRoute {
 export type RoleRouteObject = RouteObject & {
   handle?: {
     /**
-     * A route role is used to identify a route that fulfills a particular role in the site.
+     * Route roles identify the purpose(s) a route fulfills in the site.
      */
-    role?: string,
+    roles?: string[],
   },
 };
 


### PR DESCRIPTION
### Description

Brings the shell header closer to visual parity with the old `frontend-component-header` used by the legacy MFEs. This addresses the items tracked in #223.

This cascaded into a bunch of other improvements:

* The logo now links to whichever route claims the well-known `homeRole`, with a fallback redirect at `/`.

* If the `homeRole` is claimed, users that land at `/` are redirected to it.

* Active nav links get highlighted with the same dark navy background the old header used, matching `location.pathname` against the link URL (with trailing-slash normalization).

* The user dropdown replaces the generic `Person` icon and `DropdownButton` with Paragon's `AvatarButton` inside a `Dropdown`, styled as `outline-primary` to match the old design. The user's profile image is shown when available, with Paragon's default avatar fallback otherwise.

* Header content now uses `Container fluid size="xl"` instead of fixed padding, so left/right margins align with the main content area at all viewport widths. The same pattern replaces the old `px-3` / `pr-3` on both desktop and mobile layouts.

BREAKING CHANGE: Route handles switch from a single `role` string to a `roles` array so a route can serve multiple purposes.

#### Screenshots

<img width="983" height="153" alt="Image" src="https://github.com/user-attachments/assets/f8a575f9-7ffe-45cc-ade0-23edecd57392" />

_Figure 1. Before_

<img width="980" height="140" alt="image" src="https://github.com/user-attachments/assets/51e1fa1a-6308-4b67-99ce-d631b5cd104f" />

_Figure 2. After_

### LLM usage notice

Built with assistance from Claude.