### PR TITLE
fix: enable lockfile updates for in-range peer dependency versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,16 @@
       "matchPackagePatterns": ["@edx", "@openedx"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": false
+    },
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "rangeStrategy": "update-lockfile"
+    },
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "matchUpdateTypes": ["major"],
+      "rangeStrategy": "widen"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Renovate's default `rangeStrategy: "auto"` resolves to `"widen"` for peerDependencies, which only acts when a new version falls outside the existing range. In-range updates (e.g., paragon 23.20.0 -> 23.21.1 within `^23.20.0`) never get lockfile-only PRs, leaving nested transitive dependencies (like axios 0.x from paragon) pinned to old versions.
- Adds two `packageRules` entries to split peer dep handling: `"update-lockfile"` for patch/minor (always in-range, so the replace fallback never triggers) and `"widen"` for major (preserves range expansion like `^23.20.0 || ^24.0.0`).

## Test plan
- [ ] Verify Renovate generates a lockfile-only PR for `@openedx/paragon` in the top-level `package-lock.json` on next run
- [ ] Verify major peer dep updates still widen the range rather than replacing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)