### PR TITLE
fix: set renovate peer deps to  `update-lockfile`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,13 +21,7 @@
     },
     {
       "matchDepTypes": ["peerDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
       "rangeStrategy": "update-lockfile"
-    },
-    {
-      "matchDepTypes": ["peerDependencies"],
-      "matchUpdateTypes": ["major"],
-      "rangeStrategy": "widen"
     }
   ]
 }


### PR DESCRIPTION
https://github.com/openedx/frontend-base/pull/233 led to an invalid renovate config with the following error:
> `packageRules cannot combine both matchUpdateTypes and rangeStrategy`

This updates the strategy to use `update-lockfile` for all peer dependency updates.

This means that renovate will create major peer dep update PRs as replace (`^10` -> `^11`) instead of widen (`^10` -> `^10 || ^11`), but will ensure we get lockfile updates for minor and patch versions.