### PR TITLE
fix: exclude test-site from Renovate dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "automerge": false
   },
   "rebaseStalePrs": true,
+  "ignorePaths": ["test-site/**"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
## Summary
- test-site depends on a locally packed tarball (`file:../pack/openedx-frontend-base.tgz`) that isn't in git. Renovate can't build this artifact, so any lockfile update touching `test-site/package-lock.json` fails with ENOENT, causing the `renovate/artifacts` check to fail on otherwise valid PRs (e.g., #236).
- Adds `"ignorePaths": ["test-site/**"]` to the Renovate config so it stops trying to manage test-site dependencies.
- A dedicated GitHub Actions workflow (similar to [overhangio/tutor-mfe's update-site-lockfile.yml](https://github.com/overhangio/tutor-mfe/blob/frontend-base/.github/workflows/update-site-lockfile.yml)) can be set up separately to handle test-site lockfile updates.

## Test plan
- [ ] Verify Renovate no longer reports `renovate/artifacts` failures on lockfile update PRs
- [ ] Verify Renovate still creates PRs for top-level dependencies as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)