### PR TITLE
chore: enable renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended"
   ],
   "patch": {
-    "automerge": false
+    "automerge": true
   },
   "rebaseStalePrs": true,
   "ignorePaths": ["test-site/**"],
@@ -18,7 +18,7 @@
     {
       "matchPackagePatterns": ["@edx", "@openedx"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": false
+      "automerge": true
     },
     {
       "matchDepTypes": ["peerDependencies"],


### PR DESCRIPTION
This was ["temporarily" disabled](https://github.com/openedx/frontend-base/commit/2ddbf3b6da540f059d559076e3e3173a82c768ae) early in development to avoid conflicts when pulling in code from other repos. That was 2 years ago.