### PR TITLE
fix: update route handle role to roles in dev configs

### DIFF
--- a/runtime/site.config.test.tsx
+++ b/runtime/site.config.test.tsx
@@ -17,7 +17,7 @@ const siteConfig: SiteConfig = {
         <div>Test App 1</div>
       ),
       handle: {
-        role: 'test-app-1'
+        roles: ['test-app-1']
       }
     }]
   }],

--- a/shell/dev/slotShowcase/app.tsx
+++ b/shell/dev/slotShowcase/app.tsx
@@ -38,7 +38,7 @@ const app: App = {
     path: '/slots',
     Component: SlotShowcasePage,
     handle: {
-      role: 'org.openedx.frontend.role.slotShowcase',
+      roles: ['org.openedx.frontend.role.slotShowcase'],
     }
   }],
   slots: [


### PR DESCRIPTION
### Description

The route handle field was renamed from `role` (string) to `roles` (string array) as part of a prior refactor, but two files were missed in the migration: `runtime/site.config.test.tsx` and `shell/dev/slotShowcase/app.tsx`.

### LLM usage notice

Built with assistance from Claude.