### PR TITLE
fix: prevent splitChunks from emptying app.css in dev mode

### DIFF
--- a/tools/webpack/webpack.config.dev.ts
+++ b/tools/webpack/webpack.config.dev.ts
@@ -56,6 +56,14 @@ const config: Configuration = {
   optimization: {
     splitChunks: {
       chunks: 'all',
+      cacheGroups: {
+        styles: {
+          name: 'app',
+          type: 'css/mini-extract',
+          chunks: 'all',
+          enforce: true,
+        },
+      },
     },
     minimizer: getImageMinimizer(),
   },


### PR DESCRIPTION
### Description

When `shell/style.ts` was introduced in the CSS cascade layers commit, Paragon, shell, and brand CSS started being processed through `MiniCssExtractPlugin` as separate module imports rather than inlined via SCSS `@use`. This gives HtmlWebpackPlugin a CSS asset to link for the `app` entry - but `splitChunks: { chunks: 'all' }` moves the content to a numbered chunk, leaving `app.css` empty. HtmlWebpackPlugin injects the `<link href="/app.css">` tag regardless, resulting in a 404 on every dev server reload.

The fix adds a `cacheGroups` entry that consolidates all extracted CSS back into `app.css`, preventing the split. JS chunking is unaffected. The production build config is unchanged.

### LLM usage notice

Built with assistance from Claude.