### PR TITLE
feat: expose whole course metadata response in react query cache

### DIFF
--- a/shell/header/course-navigation-bar/data/service.ts
+++ b/shell/header/course-navigation-bar/data/service.ts
@@ -19,11 +19,13 @@ export interface CourseTab {
 
 export interface CourseHomeCourseMetadata {
   tabs: CourseTab[],
+  [key: string]: any,
 }
 
 function normalizeCourseHomeCourseMetadata(metadata: RawCourseHomeCourseMetadata): CourseHomeCourseMetadata {
   const data = camelCaseObject(metadata);
   return {
+    ...data,
     tabs: (data.tabs || []).map((tab: CourseTab) => ({
       tabId: tab.tabId === 'courseware' ? 'outline' : tab.tabId,
       title: tab.title,


### PR DESCRIPTION
As part of the work done on Instructor Dashboard, some attributes from the course metadata request can be useful, so instead of doing the call again we can access to react query keys and get the info from the cache, in the current implementation only the tabs were returned from that api call, so i added all the attributes from the request so it can be used on any repo if they call the query key data.

Usage Example: https://github.com/openedx/frontend-app-instructor-dashboard/pull/189

## Data on React Query
Before
<img width="1537" height="353" alt="Screenshot 2026-04-27 at 10 38 17 p m" src="https://github.com/user-attachments/assets/f63ebd0f-a231-4d82-a6dc-6c2a6b069f17" />

After
<img width="1536" height="596" alt="Screenshot 2026-04-27 at 10 37 22 p m" src="https://github.com/user-attachments/assets/9e274e8c-4f3d-4ae1-a234-e3e1fc1b078e" />
