### PR TITLE
feat: add help button to header

### DIFF
--- a/shell/Shell.messages.ts
+++ b/shell/Shell.messages.ts
@@ -55,7 +55,12 @@ const messages = defineMessages({
     id: 'footer.revealLinks.more',
     defaultMessage: 'More',
     description: 'Text for a button that reveals more links and content in the footer.',
-  }
+  },
+  'header.help': {
+    id: 'header.help',
+    defaultMessage: 'Help',
+    description: 'Help link in the global header that points to documentation or support.',
+  },
 });
 
 export default messages;

--- a/shell/header/HelpButton.test.tsx
+++ b/shell/header/HelpButton.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { IntlProvider } from '../../runtime/i18n';
+import HelpButton from './HelpButton';
+
+function renderHelpButton(getUrl: () => string | undefined) {
+  return render(
+    <IntlProvider locale="en">
+      <MemoryRouter>
+        <HelpButton getUrl={getUrl} />
+      </MemoryRouter>
+    </IntlProvider>
+  );
+}
+
+describe('HelpButton', () => {
+  it('renders nothing when getUrl returns undefined', () => {
+    const { container } = renderHelpButton(() => undefined);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when getUrl returns an empty string', () => {
+    const { container } = renderHelpButton(() => '');
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a Help link to the URL when getUrl returns a string', () => {
+    renderHelpButton(() => 'https://help.example.com');
+    const link = screen.getByRole('link', { name: 'Help' });
+    expect(link).toHaveAttribute('href', 'https://help.example.com');
+  });
+
+  it('invokes getUrl on each render so config changes are picked up', () => {
+    const getUrl = jest.fn().mockReturnValue('https://help.example.com');
+    const { rerender } = render(
+      <IntlProvider locale="en">
+        <MemoryRouter>
+          <HelpButton getUrl={getUrl} />
+        </MemoryRouter>
+      </IntlProvider>
+    );
+    expect(screen.getByRole('link', { name: 'Help' })).toHaveAttribute('href', 'https://help.example.com');
+
+    getUrl.mockReturnValue('https://help.example.com/v2');
+    rerender(
+      <IntlProvider locale="en">
+        <MemoryRouter>
+          <HelpButton getUrl={getUrl} />
+        </MemoryRouter>
+      </IntlProvider>
+    );
+    expect(screen.getByRole('link', { name: 'Help' })).toHaveAttribute('href', 'https://help.example.com/v2');
+  });
+});

--- a/shell/header/HelpButton.tsx
+++ b/shell/header/HelpButton.tsx
@@ -1,0 +1,18 @@
+import LinkMenuItem from '../menus/LinkMenuItem';
+import messages from '../Shell.messages';
+
+interface HelpButtonProps {
+  getUrl: () => string | undefined,
+}
+
+export default function HelpButton({ getUrl }: HelpButtonProps) {
+  const url = getUrl();
+  if (!url) return null;
+  return (
+    <LinkMenuItem
+      label={messages['header.help']}
+      url={url}
+      variant="navLink"
+    />
+  );
+}

--- a/shell/header/app.scss
+++ b/shell/header/app.scss
@@ -11,4 +11,10 @@ header {
       color: var(--pgn-color-active, #fff);
     }
   }
+
+  // Secondary-nav cluster sits flush against whatever's to its left
+  // (notifications bell, etc.) — those neighbors bring their own padding.
+  .secondary-nav-links > :first-child {
+    padding-left: 0;
+  }
 }

--- a/shell/header/desktop/SecondaryNavLinks.tsx
+++ b/shell/header/desktop/SecondaryNavLinks.tsx
@@ -3,7 +3,7 @@ import { Slot } from '../../../runtime';
 
 export default function SecondaryNavLinks() {
   return (
-    <Nav className="flex-nowrap">
+    <Nav className="flex-nowrap secondary-nav-links">
       <Slot id="org.openedx.frontend.slot.header.secondaryLinks.v1" />
     </Nav>
   );

--- a/shell/header/helpButtonSlotOperation.test.tsx
+++ b/shell/header/helpButtonSlotOperation.test.tsx
@@ -1,0 +1,30 @@
+import { isValidElement } from 'react';
+import { WidgetOperationTypes } from '../../runtime';
+import { mergeAppConfig } from '../../runtime/config';
+import { helpButtonSlotOperation, helpWidgetId } from './helpButtonSlotOperation';
+
+const TEST_APP_ID = 'org.openedx.frontend.app.test';
+const TEST_ROLE = 'org.openedx.frontend.role.test';
+
+describe('helpButtonSlotOperation', () => {
+  it('returns an APPEND operation targeting secondaryLinks with the shared help widget id', () => {
+    const op = helpButtonSlotOperation({ appId: TEST_APP_ID, role: TEST_ROLE });
+    expect(op.slotId).toBe('org.openedx.frontend.slot.header.secondaryLinks.v1');
+    expect(op.id).toBe(helpWidgetId);
+    expect(op.op).toBe(WidgetOperationTypes.APPEND);
+    expect(op.condition).toEqual({ active: [TEST_ROLE] });
+  });
+
+  it('produces a HelpButton element whose getUrl resolves SUPPORT_URL from the registering appId', () => {
+    mergeAppConfig(TEST_APP_ID, { SUPPORT_URL: 'https://help.example.com/test' });
+
+    const op = helpButtonSlotOperation({ appId: TEST_APP_ID, role: TEST_ROLE });
+    expect(isValidElement(op.element)).toBe(true);
+
+    const getUrl = (op.element as React.ReactElement<{ getUrl: () => string | undefined }>).props.getUrl;
+    expect(getUrl()).toBe('https://help.example.com/test');
+
+    mergeAppConfig(TEST_APP_ID, { SUPPORT_URL: 'https://help.example.com/updated' });
+    expect(getUrl()).toBe('https://help.example.com/updated');
+  });
+});

--- a/shell/header/helpButtonSlotOperation.tsx
+++ b/shell/header/helpButtonSlotOperation.tsx
@@ -1,0 +1,20 @@
+import { getAppConfig, WidgetAppendOperation, WidgetOperationTypes } from '../../runtime';
+import HelpButton from './HelpButton';
+
+export const helpWidgetId = 'org.openedx.frontend.widget.header.help.v1';
+
+export function helpButtonSlotOperation(
+  { appId, role }: { appId: string, role: string },
+): WidgetAppendOperation {
+  return {
+    slotId: 'org.openedx.frontend.slot.header.secondaryLinks.v1',
+    id: helpWidgetId,
+    op: WidgetOperationTypes.APPEND,
+    element: (
+      <HelpButton
+        getUrl={() => getAppConfig(appId).SUPPORT_URL as string | undefined}
+      />
+    ),
+    condition: { active: [role] },
+  };
+}

--- a/shell/header/index.ts
+++ b/shell/header/index.ts
@@ -1,3 +1,5 @@
 export { default as headerApp } from './app';
 export { providesCourseNavigationRolesId } from './constants';
 export { default as Header } from './Header';
+export { default as HelpButton } from './HelpButton';
+export { helpButtonSlotOperation, helpWidgetId } from './helpButtonSlotOperation';

--- a/shell/index.ts
+++ b/shell/index.ts
@@ -2,7 +2,7 @@ export { default as DefaultLayout } from './DefaultLayout';
 export { default as DefaultMain } from './DefaultMain';
 export { default as shellApp } from './app';
 export { Footer, footerApp } from './footer';
-export { providesCourseNavigationRolesId, Header, headerApp } from './header';
+export { providesCourseNavigationRolesId, Header, headerApp, HelpButton, helpButtonSlotOperation, helpWidgetId } from './header';
 export { homeRole, providesChromelessRolesId } from './constants';
 export { default as LinkMenuItem } from './menus/LinkMenuItem';
 export { default as NavDropdownMenuSlot } from './menus/NavDropdownMenuSlot';


### PR DESCRIPTION
## Summary

Frontend half of #245. Adds a reusable help button widget in the header so any app can opt in with one helper call. URL flows from runtime config (`MFE_CONFIG` / `MFE_CONFIG_OVERRIDES`, plus the help-tokens legacy fallback the backend provides for instructor-dashboard).

What this PR adds:
- `HelpButton` component (renders a `LinkMenuItem` with `variant="navLink"` when its `getUrl()` callback returns a truthy URL, otherwise null)
- `helpButtonSlotOperation({ appId, role })` helper that builds a `WidgetOperationTypes.APPEND` op for `secondaryLinks.v1`, gated by `condition.active: [role]`
- New `header.help` message
- Public exports for both
- Small SCSS fix that strips padding-left from the first `.nav-link` in `SecondaryNavLinks` so the cluster sits flush against neighboring widgets (e.g. the notifications bell) — separate commit, can be reviewed independently

Apps opt in with one line:
```ts
helpButtonSlotOperation({ appId, role: dashboardRole })
```

Companion PRs:
- openedx/frontend-app-learner-dashboard (swaps existing per-app `SupportLinkMenuItem` to the helper)
- openedx/frontend-app-instructor-dashboard (registers help button — instructor-dashboard had no help link before)
- openedx/frontend-template-site (dev-only `commonAppConfig.SUPPORT_URL` for local verification)

Backend half (already merged) provides per-app `SUPPORT_URL` via the help-tokens legacy fallback for instructor-dashboard.

## Test plan

- [x] `cd packages/frontend-base && nvm use && npm run test` — new HelpButton + helper tests, full suite green
- [x] `cd packages/frontend-base && nvm use && npm run lint` — clean
- [x] In a template-site dev, set `commonAppConfig.SUPPORT_URL` and verify Help renders on a learner-dashboard route, links to the URL, and disappears when SUPPORT_URL is empty
- [x] Set per-app override for instructor-dashboard, verify help link uses that URL when on instructor-dash routes
- [x] Confirm shell-only / auth routes (no app role active) render no help button

## Follow-up (not in this PR)

Help button on mobile — current scope is desktop only, matching the prior learner-dashboard behavior. The non-frontend-base headers vary across apps; before adding mobile, worth deciding the intended pattern rather than literally matching any one legacy app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)