### PR TITLE
fix: dedupe theme core <link> in useThemeCore

### DIFF
--- a/runtime/react/hooks/theme/useThemeCore.test.ts
+++ b/runtime/react/hooks/theme/useThemeCore.test.ts
@@ -62,4 +62,34 @@ describe('useThemeCore', () => {
     expect(document.head.querySelectorAll('link').length).toBe(0);
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
+
+  it('should not append a duplicate link when a core link for the same URL already exists', () => {
+    const existing = document.createElement('link');
+    existing.href = testParams.themeCore.url;
+    existing.rel = 'stylesheet';
+    existing.dataset.themeCore = 'true';
+    document.head.appendChild(existing);
+
+    renderHook(() => useThemeCore(testParams));
+
+    const coreLinks = document.head.querySelectorAll('link[data-theme-core="true"]');
+    expect(coreLinks.length).toBe(1);
+    expect(coreLinks[0]).toBe(existing);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should replace an existing core link when the URL changes', () => {
+    const existing = document.createElement('link');
+    existing.href = 'https://example.com/old-core.min.css';
+    existing.rel = 'stylesheet';
+    existing.dataset.themeCore = 'true';
+    document.head.appendChild(existing);
+
+    renderHook(() => useThemeCore(testParams));
+
+    const coreLinks = document.head.querySelectorAll('link[data-theme-core="true"]');
+    expect(coreLinks.length).toBe(1);
+    expect(coreLinks[0]).not.toBe(existing);
+    expect((coreLinks[0] as HTMLLinkElement).href).toBe(testParams.themeCore.url);
+  });
 });

--- a/runtime/react/hooks/theme/useThemeCore.ts
+++ b/runtime/react/hooks/theme/useThemeCore.ts
@@ -27,6 +27,15 @@ const useThemeCore = ({
       return;
     }
 
+    const existingThemeCoreLink: HTMLLinkElement | null = document.head.querySelector('link[data-theme-core="true"]');
+    if (existingThemeCoreLink) {
+      if (existingThemeCoreLink.getAttribute('href') === themeCore.url) {
+        setIsThemeCoreComplete(true);
+        return;
+      }
+      existingThemeCoreLink.remove();
+    }
+
     const themeCoreLink = document.createElement('link');
     themeCoreLink.href = themeCore.url;
     themeCoreLink.rel = 'stylesheet';


### PR DESCRIPTION
### Description

Under React StrictMode the `useThemeCore` effect ran twice on mount and appended a second core stylesheet after the variant `<link>`, which let core `:root` declarations override the variant for any custom properties they happened to share. The effect now looks for an existing `link[data-theme-core="true"]` first: if its href matches the target URL it reuses it, and if the URL has changed it removes the stale link before appending the new one. This mirrors the dedup pattern already used by `useThemeVariants`.

Closes #261

### LLM usage notice

Built with assistance from Claude.