### PR TITLE
Adopt the release-branch publishing model (ADR 0012 + config)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - release
 
 permissions:
   id-token: write  # Required for OIDC

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,7 @@
 {
   "branches": [
-    "placeholder",
-    { "name": "main", "prerelease": "alpha", "channel": "latest" }
+    { "name": "release", "channel": "latest" },
+    { "name": "main", "prerelease": "alpha" }
   ],
   "tagFormat": "v${version}",
   "plugins": [

--- a/docs/decisions/0012-frontend-branching-strategy.rst
+++ b/docs/decisions/0012-frontend-branching-strategy.rst
@@ -63,19 +63,32 @@ frontend-app-authn@2.0.0-alpha2
 3. Creation and publication of release branches
 -----------------------------------------------
 
-When the main branch of a given frontend repository contains breaking changes
-over the current release and is deemed ready for widespread use, a new "n.x"
-branch is cut from it, where "n" is the next major version of the package.  The
-".x" is literal.  For instance:
+The current stable codebase is published from a long-lived ``release`` branch.
+This branch owns the NPM "latest" dist-tag and is published semantically, with
+no breaking changes allowed after publication:
+
+frontend-base@1.0.5
+frontend-app-authn@1.4.3
+
+When the main branch contains breaking changes over the current release and is
+deemed ready for widespread use, its work graduates onto ``release`` as the next
+major.  Before that happens, an "n.x" branch is cut from ``release`` to continue
+maintaining the outgoing major, where "n" is that major's number and the ".x" is
+literal.  For instance, when ``release`` moves from the 1.x line to the 2.x line,
+a ``1.x`` branch is cut to keep publishing 1.x.y patches:
 
 1.x
 2.x
 
-These branches are also published to NPM semantically, with no breaking changes
-allowed after publication:
+These maintenance branches are also published semantically, with no breaking
+changes allowed.
 
-frontend-base@1.0.5
-frontend-app-authn@1.4.3
+.. note::
+
+   We publish the current stable from ``release`` rather than an "n.x" branch
+   because our release tooling (semantic-release) treats any "N.x"-named branch
+   as a maintenance branch, which can only patch an already-shipped major, never
+   originate one.  A ``release`` branch has no such restriction.
 
 
 4. Backports


### PR DESCRIPTION
### Description

Adopt the `release`-branch publishing model for `frontend-base`, both in the decision record and in the release configuration.

The ADR change amends section 3 of ADR 0012: the current stable is published from a long-lived `release` branch, which is a true release branch (it owns the npm `latest` dist-tag and can originate a major's first stable release), while `n.x` branches are retained for maintaining superseded majors, cut from `release` once the next major ships. A short note records why: semantic-release classifies any `N.x`-named branch as a maintenance branch, which can only patch an already-shipped major, never originate one.

The config change puts that model into effect. The `branches` config publishes the current stable from `release` (npm `latest`) and `-alpha` prereleases from `main` (the `alpha` dist-tag), replacing the `placeholder` entry and dropping `channel: latest` from `main`. The release workflow triggers on both `main` and `release`, keeping the configuration byte-identical on both branches.

Note on merge order: do not merge until the `release` branch has been cut and published. Until a `release` branch exists on the remote, `main`'s release workflow would fail with `ERELEASEBRANCHES`, because the config references a release branch that is not yet present. The `release` branch is created as part of #244.

Closes #273.

### LLM usage notice

Built with assistance from Claude.
