### PR TITLE
fix: add missing SiteConfig service override typings and definitions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ module.exports = tseslint.config(
       'test-site/*',
       'config/*',
       'docs/*',
+      'test-types/*',
     ],
   },
 );

--- a/runtime/analytics/types.ts
+++ b/runtime/analytics/types.ts
@@ -1,0 +1,7 @@
+export interface AnalyticsService {
+  sendTrackingLogEvent(eventName: string, properties: object): Promise<void>,
+  identifyAuthenticatedUser(userId: string | number, traits?: Record<string, unknown>): void,
+  identifyAnonymousUser(traits?: Record<string, unknown>): void,
+  sendTrackEvent(eventName?: string, properties?: Record<string, unknown>): void,
+  sendPageEvent(category: string, name: string, properties?: Record<string, unknown>): void,
+}

--- a/runtime/auth/types.ts
+++ b/runtime/auth/types.ts
@@ -1,0 +1,13 @@
+export interface AuthService {
+  getAuthenticatedHttpClient(options?: Record<string, unknown>): unknown,
+  getHttpClient(options?: Record<string, unknown>): unknown,
+  getLoginRedirectUrl(redirectUrl?: string): string,
+  redirectToLogin(redirectUrl?: string): void,
+  getLogoutRedirectUrl(redirectUrl?: string): string,
+  redirectToLogout(redirectUrl?: string): void,
+  getAuthenticatedUser(): Record<string, unknown> | null,
+  setAuthenticatedUser(authUser: Record<string, unknown>): void,
+  fetchAuthenticatedUser(options?: Record<string, unknown>): Promise<Record<string, unknown> | null>,
+  ensureAuthenticatedUser(redirectUrl?: string): Promise<Record<string, unknown>>,
+  hydrateAuthenticatedUser(): Promise<null>,
+}

--- a/test-types/site-config-service-overrides.typecheck.ts
+++ b/test-types/site-config-service-overrides.typecheck.ts
@@ -1,0 +1,18 @@
+import { SiteConfig } from '../types';
+import NewRelicLoggingService from '../runtime/logging/NewRelicLoggingService';
+import SegmentAnalyticsService from '../runtime/analytics/SegmentAnalyticsService';
+import AxiosJwtAuthService from '../runtime/auth/AxiosJwtAuthService';
+
+const config: SiteConfig = {
+    loggingService: NewRelicLoggingService,
+    analyticsService: SegmentAnalyticsService,
+    authService: AxiosJwtAuthService,
+    siteId: '',
+    siteName: '',
+    baseUrl: '',
+    lmsBaseUrl: '',
+    loginUrl: '',
+    logoutUrl: '',
+}
+
+export default config;

--- a/types.ts
+++ b/types.ts
@@ -59,6 +59,31 @@ export interface RequiredSiteConfig {
 export type LocalizedMessages = Record<string, Record<string, string>>;
 export type SiteMessages = LocalizedMessages[];
 
+// Generic logger contract
+export interface LoggingService {
+  debug?(message: string, meta?: Record<string, unknown>): void,
+  info?(message: string, meta?: Record<string, unknown>): void,
+  warn?(message: string, meta?: Record<string, unknown>): void,
+  error?(message: string | Error, meta?: Record<string, unknown>): void,
+}
+
+// Generic analytics contract
+export interface AnalyticsService {
+  identify?(userId: string | number, traits?: Record<string, unknown>): void,
+  track(event: string, properties?: Record<string, unknown>): void,
+  page?(name?: string, properties?: Record<string, unknown>): void,
+  reset?(): void,
+}
+
+// Generic auth contract
+export interface AuthService {
+  isAuthenticated(): boolean | Promise<boolean>,
+  getAccessToken?(): string | null | Promise<string | null>,
+  login?(redirectUrl?: string): void | Promise<void>,
+  logout?(redirectUrl?: string): void | Promise<void>,
+  getCurrentUser?(): User | null | Promise<User | null>,
+}
+
 export interface OptionalSiteConfig {
   // Site environment
   environment: EnvironmentTypes,
@@ -92,6 +117,11 @@ export interface OptionalSiteConfig {
 
   // Analytics
   segmentKey: string | null,
+
+  // Services
+  loggingService: LoggingService,
+  analyticsService: AnalyticsService,
+  authService: AuthService,
 }
 
 export type SiteConfig = RequiredSiteConfig & Partial<OptionalSiteConfig>;

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,9 @@ import { FC, ReactElement, ReactNode } from 'react';
 import { MessageDescriptor } from 'react-intl';
 import { RouteObject } from 'react-router';
 import { SlotOperation } from './runtime/slots/types';
+import { LoggingService } from './runtime/logging/types';
+import { AnalyticsService } from './runtime/analytics/types';
+import { AuthService } from './runtime/auth/types';
 
 // Apps
 
@@ -59,30 +62,34 @@ export interface RequiredSiteConfig {
 export type LocalizedMessages = Record<string, Record<string, string>>;
 export type SiteMessages = LocalizedMessages[];
 
-// Generic logger contract
-export interface LoggingService {
-  debug?(message: string, meta?: Record<string, unknown>): void,
-  info?(message: string, meta?: Record<string, unknown>): void,
-  warn?(message: string, meta?: Record<string, unknown>): void,
-  error?(message: string | Error, meta?: Record<string, unknown>): void,
-}
+export type { LoggingService, AnalyticsService, AuthService };
 
-// Generic analytics contract
-export interface AnalyticsService {
-  identify?(userId: string | number, traits?: Record<string, unknown>): void,
-  track(event: string, properties?: Record<string, unknown>): void,
-  page?(name?: string, properties?: Record<string, unknown>): void,
-  reset?(): void,
-}
+// Logging instantiated
+export type LoggingServiceClass = new (options: {
+  config: SiteConfig,
+}) => LoggingService;
 
-// Generic auth contract
-export interface AuthService {
-  isAuthenticated(): boolean | Promise<boolean>,
-  getAccessToken?(): string | null | Promise<string | null>,
-  login?(redirectUrl?: string): void | Promise<void>,
-  logout?(redirectUrl?: string): void | Promise<void>,
-  getCurrentUser?(): User | null | Promise<User | null>,
-}
+// Analytics instantiated
+export type AnalyticsServiceClass = new (options: {
+  config: SiteConfig,
+  loggingService: LoggingService,
+  httpClient: unknown,
+}) => AnalyticsService;
+
+// Auth instantiated
+export type AuthServiceClass = new (options: {
+  config: {
+    baseUrl: string,
+    lmsBaseUrl: string,
+    loginUrl: string,
+    logoutUrl: string,
+    refreshAccessTokenApiPath: string,
+    accessTokenCookieName: string,
+    csrfTokenApiPath: string,
+  },
+  loggingService: object,
+  middleware?: unknown[],
+}) => AuthService;
 
 export interface OptionalSiteConfig {
   // Site environment
@@ -119,9 +126,9 @@ export interface OptionalSiteConfig {
   segmentKey: string | null,
 
   // Services
-  loggingService: LoggingService,
-  analyticsService: AnalyticsService,
-  authService: AuthService,
+  loggingService: LoggingServiceClass,
+  analyticsService: AnalyticsServiceClass,
+  authService: AuthServiceClass,
 }
 
 export type SiteConfig = RequiredSiteConfig & Partial<OptionalSiteConfig>;


### PR DESCRIPTION

## Description

This PR aligns the SiteConfig TypeScript definitions with the existing runtime implementation.

The runtime initialize() function supports overriding the default service implementations through properties defined on SiteConfig:

- loggingService
- analyticsService
- authService

However, these properties are currently not represented in the SiteConfig TypeScript definitions. As a result, consumers receive TypeScript compilation errors when attempting to register supported service overrides through site configuration.

## Fix

Add the missing service override definitions to OptionalSiteConfig so that the TypeScript API matches the existing runtime behavior.

## Validation

- TypeScript compilation succeeds
- No runtime changes introduced

## Context

Discovered while attempting to configure a custom logging service.

## LLM usage notice

Built with assistance from Copilot.


Closes #293
