### PR TITLE
feat!: use semicolons for TypeScript member delimiters

### DIFF
--- a/runtime/config/index.ts
+++ b/runtime/config/index.ts
@@ -179,7 +179,7 @@ export function setSiteConfig(newSiteConfig: SiteConfig) {
 }
 
 interface MergeSiteConfigOptions {
-  limitAppMergeToConfig?: boolean,
+  limitAppMergeToConfig?: boolean;
 }
 
 /**

--- a/runtime/i18n/lib.ts
+++ b/runtime/i18n/lib.ts
@@ -238,7 +238,7 @@ export function mergeMessages(newMessages = {}) {
 }
 
 interface ConfigureI18nOptions {
-  messages: LocalizedMessages[] | LocalizedMessages,
+  messages: LocalizedMessages[] | LocalizedMessages;
 }
 
 /**

--- a/runtime/logging/types.ts
+++ b/runtime/logging/types.ts
@@ -1,4 +1,4 @@
 export interface LoggingService {
-  logError: (errorStringOrObject: string | Error, customAttributes: any) => void,
-  logInfo: (infoStringOrErrorObject: string | Error, customAttributes: any) => void,
+  logError: (errorStringOrObject: string | Error, customAttributes: any) => void;
+  logInfo: (infoStringOrErrorObject: string | Error, customAttributes: any) => void;
 }

--- a/runtime/react/CombinedAppProvider.tsx
+++ b/runtime/react/CombinedAppProvider.tsx
@@ -3,7 +3,7 @@ import { App, AppProvider } from '../../types';
 import { getSiteConfig } from '../config';
 
 interface CombinedAppProviderProps {
-  children: ReactNode,
+  children: ReactNode;
 }
 
 export default function CombinedAppProvider({ children }: CombinedAppProviderProps) {

--- a/runtime/react/CurrentAppContext.tsx
+++ b/runtime/react/CurrentAppContext.tsx
@@ -17,7 +17,7 @@ import { AppConfig } from '../../types';
  * @memberof module:React
  */
 const CurrentAppContext = createContext<{
-  appConfig: AppConfig,
+  appConfig: AppConfig;
 }>({
   appConfig: {},
 });

--- a/runtime/react/CurrentAppProvider.tsx
+++ b/runtime/react/CurrentAppProvider.tsx
@@ -7,8 +7,8 @@ import CurrentAppContext from './CurrentAppContext';
 import { useSiteEvent } from './hooks';
 
 interface CurrentAppProviderProps {
-  appId: string,
-  children: ReactNode,
+  appId: string;
+  children: ReactNode;
 }
 
 /**

--- a/runtime/react/SiteContext.tsx
+++ b/runtime/react/SiteContext.tsx
@@ -20,9 +20,9 @@ import { getSiteConfig } from '../config';
  * @memberof module:React
  */
 const SiteContext = createContext<{
-  authenticatedUser: User | null,
-  siteConfig: SiteConfig,
-  locale: string,
+  authenticatedUser: User | null;
+  siteConfig: SiteConfig;
+  locale: string;
 }>({
   authenticatedUser: null,
   siteConfig: getSiteConfig(),

--- a/runtime/react/SiteProvider.tsx
+++ b/runtime/react/SiteProvider.tsx
@@ -22,7 +22,7 @@ import {
 import { themeActions } from './reducers';
 
 interface SiteProviderProps {
-  children: ReactNode,
+  children: ReactNode;
 }
 
 /**

--- a/runtime/react/hooks/theme/useThemeVariants.ts
+++ b/runtime/react/hooks/theme/useThemeVariants.ts
@@ -19,10 +19,10 @@ const useThemeVariants = ({
   onComplete,
   onDarkModeSystemPreferenceChange,
 }: {
-  themeVariants: ThemeVariants | undefined,
-  currentThemeVariant: string,
-  onComplete: () => void,
-  onDarkModeSystemPreferenceChange: (prefersDarkMode: boolean) => void,
+  themeVariants: ThemeVariants | undefined;
+  currentThemeVariant: string;
+  onComplete: () => void;
+  onDarkModeSystemPreferenceChange: (prefersDarkMode: boolean) => void;
 }) => {
   const [isThemeVariantComplete, setIsThemeVariantComplete] = useState(false);
 

--- a/runtime/slots/Slot.tsx
+++ b/runtime/slots/Slot.tsx
@@ -5,11 +5,11 @@ import SlotContext from './SlotContext';
 import { useSlotContext } from './hooks';
 
 interface SlotProps {
-  id: string,
-  idAliases?: string[],
-  children?: ReactNode,
-  layout?: ComponentType | ReactNode,
-  [key: string]: unknown,
+  id: string;
+  idAliases?: string[];
+  children?: ReactNode;
+  layout?: ComponentType | ReactNode;
+  [key: string]: unknown;
 }
 
 function SlotRenderer({ layout }: { layout: ComponentType | ReactNode }) {

--- a/runtime/slots/SlotContext.tsx
+++ b/runtime/slots/SlotContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode } from 'react';
 
-const SlotContext = createContext<{ id: string, idAliases?: string[], children?: ReactNode, [key: string]: unknown }>({
+const SlotContext = createContext<{ id: string; idAliases?: string[]; children?: ReactNode; [key: string]: unknown }>({
   id: '',
   children: null,
 });

--- a/runtime/slots/layout/types.ts
+++ b/runtime/slots/layout/types.ts
@@ -14,22 +14,22 @@ export enum LayoutOperationTypes {
 }
 
 export interface BaseLayoutOperation extends BaseSlotOperation {
-  op: LayoutOperationTypes,
+  op: LayoutOperationTypes;
 }
 
 // Concrete UI Layout Operations
 
 export type LayoutOptionsOperation = BaseLayoutOperation & {
-  op: LayoutOperationTypes.OPTIONS,
-  options: Record<string, unknown>,
+  op: LayoutOperationTypes.OPTIONS;
+  options: Record<string, unknown>;
 };
 
 export interface LayoutComponentProps {
-  component: React.ComponentType,
+  component: React.ComponentType;
 }
 
 export interface LayoutElementProps {
-  element: ReactNode,
+  element: ReactNode;
 }
 
 export type LayoutRendererProps = (
@@ -37,7 +37,7 @@ export type LayoutRendererProps = (
 );
 
 export type LayoutReplaceOperation = BaseLayoutOperation & LayoutRendererProps & {
-  op: LayoutOperationTypes.REPLACE,
+  op: LayoutOperationTypes.REPLACE;
 };
 
 // Aggregate UI Layout Operations

--- a/runtime/slots/types.ts
+++ b/runtime/slots/types.ts
@@ -8,15 +8,15 @@ import { LayoutOperation } from './layout/types';
 import { WidgetOperation } from './widget/types';
 
 export interface SlotOperationCondition {
-  active?: string[],
-  inactive?: string[],
-  authenticated?: boolean,
-  callback?: () => boolean,
+  active?: string[];
+  inactive?: string[];
+  authenticated?: boolean;
+  callback?: () => boolean;
 }
 
 export interface BaseSlotOperation {
-  slotId: string,
-  condition?: SlotOperationCondition,
+  slotId: string;
+  condition?: SlotOperationCondition;
 }
 
 // Aggregate Slot Operations

--- a/runtime/slots/widget/WidgetContext.tsx
+++ b/runtime/slots/widget/WidgetContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-const WidgetContext = createContext<{ slotId: string, widgetId: string, role?: string }>({
+const WidgetContext = createContext<{ slotId: string; widgetId: string; role?: string }>({
   slotId: '',
   widgetId: '',
   role: undefined,

--- a/runtime/slots/widget/WidgetProvider.tsx
+++ b/runtime/slots/widget/WidgetProvider.tsx
@@ -4,10 +4,10 @@ import { addActiveWidgetRole, removeActiveWidgetRole } from '../../config';
 import WidgetContext from './WidgetContext';
 
 interface WidgetProviderProps {
-  children: ReactNode,
-  slotId: string,
-  widgetId: string,
-  role?: string,
+  children: ReactNode;
+  slotId: string;
+  widgetId: string;
+  role?: string;
 }
 
 export default function WidgetProvider({ children, slotId, widgetId, role }: WidgetProviderProps) {

--- a/runtime/slots/widget/iframe/IFrameContentWrapper.tsx
+++ b/runtime/slots/widget/iframe/IFrameContentWrapper.tsx
@@ -27,11 +27,11 @@ const ErrorFallbackDefault = () => {
 };
 
 interface IFrameContentWrapperProps {
-  children: ReactNode,
-  className?: string,
-  style?: Record<string, string>,
-  ready?: boolean,
-  errorFallbackComponent?: FunctionComponent,
+  children: ReactNode;
+  className?: string;
+  style?: Record<string, string>;
+  ready?: boolean;
+  errorFallbackComponent?: FunctionComponent;
 }
 
 export default function IFrameContentWrapper({

--- a/runtime/slots/widget/iframe/IFrameWidget.tsx
+++ b/runtime/slots/widget/iframe/IFrameWidget.tsx
@@ -6,8 +6,8 @@ import { dispatchPluginEvent, useElementSize, usePluginEvent } from './hooks';
 import { IFRAME_FEATURE_POLICY, IFRAME_MOUNTED, IFRAME_READY, IFRAME_RESIZE } from './constants';
 
 interface IFrameWidgetProps {
-  url: string,
-  title: string,
+  url: string;
+  title: string;
 }
 
 export default function IFrameWidget({ url, title }: IFrameWidgetProps) {

--- a/runtime/slots/widget/iframe/hooks.ts
+++ b/runtime/slots/widget/iframe/hooks.ts
@@ -26,7 +26,7 @@ export function useMessageEvent(srcWindow: Window | null, type: string, callback
   // useLayoutEffect is called before the browser repaints the screen
   useLayoutEffect(() => {
     // Create a listener callback function
-    const listener = (event: MessageEvent<{ type: string, payload: any }>) => {
+    const listener = (event: MessageEvent<{ type: string; payload: any }>) => {
       // Filter messages to those from our source window.
       // NOTE: the "srcWindow" is determined by the below useHostEvent and usePluginEvent functions
       if (event.source === srcWindow) {
@@ -159,12 +159,12 @@ export function useElementSize() {
   }, [element]);
 
   return useMemo<{
-    ref: LegacyRef<HTMLIFrameElement>,
-    element: HTMLIFrameElement | undefined,
-    width: number,
-    height: number,
-    x: number,
-    y: number,
+    ref: LegacyRef<HTMLIFrameElement>;
+    element: HTMLIFrameElement | undefined;
+    width: number;
+    height: number;
+    x: number;
+    y: number;
   }>(
     () => ({
       ref: measuredRef,

--- a/runtime/slots/widget/iframe/types.ts
+++ b/runtime/slots/widget/iframe/types.ts
@@ -1,6 +1,6 @@
 export interface MessageEventCallbackParams {
-  type: string,
-  payload: any,
+  type: string;
+  payload: any;
 }
 
 export type MessageEventCallback = ({ type, payload }: MessageEventCallbackParams) => void;

--- a/runtime/slots/widget/types.ts
+++ b/runtime/slots/widget/types.ts
@@ -53,22 +53,22 @@ export type AbsoluteWidgetOperationTypes = WidgetOperationTypes.APPEND | WidgetO
 export type RelativeWidgetOperationTypes = WidgetOperationTypes.INSERT_AFTER | WidgetOperationTypes.INSERT_BEFORE | WidgetOperationTypes.REPLACE | WidgetOperationTypes.OPTIONS;
 
 export interface BaseWidgetOperation extends BaseSlotOperation {
-  op: WidgetOperationTypes,
+  op: WidgetOperationTypes;
 }
 
 // Widget renderer props
 
 export interface WidgetComponentProps {
-  component: React.ComponentType,
+  component: React.ComponentType;
 }
 
 export interface WidgetElementProps {
-  element: ReactNode,
+  element: ReactNode;
 }
 
 export interface WidgetIFrameProps {
-  url: string,
-  title: string,
+  url: string;
+  title: string;
 }
 
 export type WidgetRendererProps = (
@@ -76,39 +76,39 @@ export type WidgetRendererProps = (
 );
 
 export interface WidgetIdentityProps {
-  id: string,
-  role?: string,
+  id: string;
+  role?: string;
 }
 
 export interface WidgetRelationshipProps {
-  relatedId: string,
+  relatedId: string;
 }
 
 // Concrete UI Widget Operations
 
 export type WidgetAppendOperation = BaseWidgetOperation & WidgetIdentityProps & WidgetRendererProps & {
-  op: WidgetOperationTypes.APPEND,
+  op: WidgetOperationTypes.APPEND;
 };
 
 export type WidgetPrependOperation = BaseWidgetOperation & WidgetIdentityProps & WidgetRendererProps & {
-  op: WidgetOperationTypes.PREPEND,
+  op: WidgetOperationTypes.PREPEND;
 };
 
 export type WidgetInsertAfterOperation = BaseWidgetOperation & WidgetIdentityProps & WidgetRendererProps & WidgetRelationshipProps & {
-  op: WidgetOperationTypes.INSERT_AFTER,
+  op: WidgetOperationTypes.INSERT_AFTER;
 };
 
 export type WidgetInsertBeforeOperation = BaseWidgetOperation & WidgetIdentityProps & WidgetRendererProps & WidgetRelationshipProps & {
-  op: WidgetOperationTypes.INSERT_BEFORE,
+  op: WidgetOperationTypes.INSERT_BEFORE;
 };
 
 export type WidgetRemoveOperation = BaseWidgetOperation & WidgetRelationshipProps & {
-  op: WidgetOperationTypes.REMOVE,
+  op: WidgetOperationTypes.REMOVE;
 };
 
 export type WidgetOptionsOperation = BaseWidgetOperation & WidgetRelationshipProps & {
-  op: WidgetOperationTypes.OPTIONS,
-  options: Record<string, unknown>,
+  op: WidgetOperationTypes.OPTIONS;
+  options: Record<string, unknown>;
 };
 
 export type WidgetReplaceOperation = BaseWidgetOperation & WidgetIdentityProps & WidgetRendererProps & WidgetRelationshipProps & { op: WidgetOperationTypes.REPLACE };
@@ -129,15 +129,15 @@ export type WidgetOperation = WidgetAbsoluteOperation | WidgetRelativeOperation;
  * ID for relative widget operations.
  */
 export interface IdentifiedWidget {
-  id: string,
-  role?: string,
-  node: ReactNode,
+  id: string;
+  role?: string;
+  node: ReactNode;
 }
 
 export interface WidgetList extends Array<ReactNode> {
-  identified: IdentifiedWidget[],
-  byId(id: string): ReactNode[],
-  withoutId(id: string): ReactNode[],
-  byRole(role: string): ReactNode[],
-  withoutRole(role: string): ReactNode[],
+  identified: IdentifiedWidget[];
+  byId(id: string): ReactNode[];
+  withoutId(id: string): ReactNode[];
+  byRole(role: string): ReactNode[];
+  withoutRole(role: string): ReactNode[];
 }

--- a/runtime/testing/initializeMockApp.ts
+++ b/runtime/testing/initializeMockApp.ts
@@ -50,8 +50,8 @@ export default function initializeMockApp({
   messages = mockMessages,
   authenticatedUser = null,
 }: {
-  messages?: LocalizedMessages,
-  authenticatedUser?: User | null,
+  messages?: LocalizedMessages;
+  authenticatedUser?: User | null;
 } = {}) {
   const config = siteConfig;
   mergeSiteConfig(config);

--- a/shell/Logo.tsx
+++ b/shell/Logo.tsx
@@ -5,8 +5,8 @@ import { getUrlByRouteRole } from '../runtime/routing';
 import { homeRole } from './constants';
 
 interface LogoProps {
-  imageUrl?: string,
-  destinationUrl?: string,
+  imageUrl?: string;
+  destinationUrl?: string;
 }
 
 export default function Logo({

--- a/shell/dev/devHeader/BarContext.tsx
+++ b/shell/dev/devHeader/BarContext.tsx
@@ -1,8 +1,8 @@
 import { createContext, Dispatch, SetStateAction } from 'react';
 
 interface BarContextInterface {
-  bar: string,
-  setBar: Dispatch<SetStateAction<string>>,
+  bar: string;
+  setBar: Dispatch<SetStateAction<string>>;
 };
 
 const BarContext = createContext<BarContextInterface>({

--- a/shell/dev/devHeader/BarProvider.tsx
+++ b/shell/dev/devHeader/BarProvider.tsx
@@ -6,7 +6,7 @@ function getBar() {
 }
 
 interface BarProviderProps {
-  children?: ReactNode,
+  children?: ReactNode;
 }
 
 export default function BarProvider({ children }: BarProviderProps) {

--- a/shell/dev/devHeader/FooContext.tsx
+++ b/shell/dev/devHeader/FooContext.tsx
@@ -1,8 +1,8 @@
 import { createContext, Dispatch, SetStateAction } from 'react';
 
 interface FooContextInterface {
-  foo: string,
-  setFoo: Dispatch<SetStateAction<string>>,
+  foo: string;
+  setFoo: Dispatch<SetStateAction<string>>;
 };
 
 const FooContext = createContext<FooContextInterface>({

--- a/shell/dev/devHeader/FooProvider.tsx
+++ b/shell/dev/devHeader/FooProvider.tsx
@@ -6,7 +6,7 @@ function getFoo() {
 }
 
 interface FooProviderProps {
-  children?: ReactNode,
+  children?: ReactNode;
 }
 
 export default function FooProvider({ children }: FooProviderProps) {

--- a/shell/dev/slotShowcase/SlotShowcasePage.tsx
+++ b/shell/dev/slotShowcase/SlotShowcasePage.tsx
@@ -16,7 +16,7 @@ function SlotContainer({ children }: { children: ReactNode }) {
   );
 }
 
-function Section({ title, children }: { title: string, children: ReactNode }) {
+function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div>
       <h3 className="text-primary-500">{title}</h3>

--- a/shell/dev/slotShowcase/app.tsx
+++ b/shell/dev/slotShowcase/app.tsx
@@ -6,7 +6,7 @@ import HorizontalSlotLayout from './HorizontalSlotLayout';
 import SlotShowcasePage from './SlotShowcasePage';
 import WidgetWithOptions from './WidgetWithOptions';
 
-function Widget({ title, op, className, ...props }: { title: string, op?: string, className?: string } & Record<string, unknown>) {
+function Widget({ title, op, className, ...props }: { title: string; op?: string; className?: string } & Record<string, unknown>) {
   return (
     <div className={`showcase-widget ${className ?? ''}`} {...props}>
       {title}

--- a/shell/footer/CopyrightNotice.tsx
+++ b/shell/footer/CopyrightNotice.tsx
@@ -3,12 +3,12 @@ import { Hyperlink } from '@openedx/paragon';
 import { useSiteConfig } from '../../runtime';
 
 interface CopyrightNoticeProps {
-  title?: string,
+  title?: string;
   /**
    * The URL that the copyright notice should link to when a user clicks on the title.  If not set,
    * the title will not be a link.
    */
-  destination?: string,
+  destination?: string;
 }
 
 export default function CopyrightNotice({ title, destination }: CopyrightNoticeProps) {

--- a/shell/footer/LanguageMenuItem.tsx
+++ b/shell/footer/LanguageMenuItem.tsx
@@ -5,9 +5,9 @@ import { updateSiteLanguage } from './data/api';
 
 interface LanguageMenuItemProps {
   language: {
-    code: string,
-    name: string,
-  },
+    code: string;
+    name: string;
+  };
 }
 
 export default function LanguageMenuItem({ language }: LanguageMenuItemProps) {

--- a/shell/header/AuthenticatedMenu.tsx
+++ b/shell/header/AuthenticatedMenu.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../runtime';
 
 interface AuthenticatedMenuProps {
-  className?: string,
+  className?: string;
 }
 
 export default function AuthenticatedMenu({ className }: AuthenticatedMenuProps) {

--- a/shell/header/HelpButton.tsx
+++ b/shell/header/HelpButton.tsx
@@ -2,7 +2,7 @@ import LinkMenuItem from '../menus/LinkMenuItem';
 import messages from '../Shell.messages';
 
 interface HelpButtonProps {
-  getUrl: () => string | undefined,
+  getUrl: () => string | undefined;
 }
 
 export default function HelpButton({ getUrl }: HelpButtonProps) {

--- a/shell/header/anonymous-menu/AnonymousMenu.tsx
+++ b/shell/header/anonymous-menu/AnonymousMenu.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import { Slot } from '../../../runtime';
 
 interface AnonymousMenuProps {
-  className?: string,
+  className?: string;
 }
 
 export default function AnonymousMenu({ className }: AnonymousMenuProps) {

--- a/shell/header/course-bar/data/service.ts
+++ b/shell/header/course-bar/data/service.ts
@@ -3,23 +3,23 @@ import { getSiteConfig, getAuthenticatedHttpClient, camelCaseObject } from '../.
 
 // Raw API response from /api/course_home/course_metadata/
 interface RawCourseTab {
-  tab_id: string,
-  title: string,
-  url: string,
+  tab_id: string;
+  title: string;
+  url: string;
 }
 
 interface RawCourseHomeCourseMetadata {
-  tabs: RawCourseTab[],
+  tabs: RawCourseTab[];
 }
 
 export interface CourseTab {
-  tabId: string,
-  title: string,
-  url: string,
+  tabId: string;
+  title: string;
+  url: string;
 }
 
 export interface CourseHomeCourseMetadata {
-  tabs: CourseTab[],
+  tabs: CourseTab[];
 }
 
 function normalizeCourseHomeCourseMetadata(metadata: RawCourseHomeCourseMetadata): CourseHomeCourseMetadata {
@@ -50,7 +50,7 @@ export function courseHomeCourseMetadataQueryKey(courseId: string): [string, str
  * user can still see the page they're on.
  */
 export function findActiveTab(tabs: CourseTab[], pathname: string): CourseTab | null {
-  let best: { tab: CourseTab, length: number } | null = null;
+  let best: { tab: CourseTab; length: number } | null = null;
   for (const tab of tabs) {
     const tabPathname = new URL(tab.url).pathname;
     const match = matchPath({ path: `${tabPathname}/*`, end: false }, pathname);

--- a/shell/header/course-bar/masquerade/StudioLink.tsx
+++ b/shell/header/course-bar/masquerade/StudioLink.tsx
@@ -4,8 +4,8 @@ import { Button } from '@openedx/paragon';
 import messages from './messages';
 
 interface Props {
-  courseId?: string,
-  unitId?: string,
+  courseId?: string;
+  unitId?: string;
 }
 
 function buildStudioUrl(courseId?: string, unitId?: string): string | null {

--- a/shell/header/course-bar/masquerade/data/api.ts
+++ b/shell/header/course-bar/masquerade/data/api.ts
@@ -3,33 +3,33 @@ import { getSiteConfig, camelCaseObject, getAuthenticatedHttpClient } from '@ope
 export type Role = 'staff' | 'student';
 
 export interface ActiveMasqueradeData {
-  role: Role,
-  userName: string | null,
-  userPartitionId: number | null,
-  groupId: number | null,
-  groupName: string | null,
+  role: Role;
+  userName: string | null;
+  userPartitionId: number | null;
+  groupId: number | null;
+  groupName: string | null;
 }
 
 export interface MasqueradeOption {
-  name: string,
-  role: Role,
-  userName?: string,
-  groupId?: number,
-  userPartitionId?: number,
+  name: string;
+  role: Role;
+  userName?: string;
+  groupId?: number;
+  userPartitionId?: number;
 }
 
 export interface MasqueradeStatus {
-  success: boolean,
-  error?: string,
-  active: ActiveMasqueradeData,
-  available: MasqueradeOption[],
+  success: boolean;
+  error?: string;
+  active: ActiveMasqueradeData;
+  available: MasqueradeOption[];
 }
 
 export interface MasqueradePayload {
-  role?: Role,
-  user_name?: string,
-  group_id?: number,
-  user_partition_id?: number,
+  role?: Role;
+  user_name?: string;
+  group_id?: number;
+  user_partition_id?: number;
 }
 
 export async function getMasqueradeOptions(courseId: string): Promise<MasqueradeStatus> {

--- a/shell/header/course-bar/masquerade/hooks.ts
+++ b/shell/header/course-bar/masquerade/hooks.ts
@@ -60,7 +60,7 @@ export function isOptionSelected(option: MasqueradeOption, active: ActiveMasquer
 }
 
 interface HttpishError {
-  customAttributes?: { httpErrorStatus?: number },
+  customAttributes?: { httpErrorStatus?: number };
 }
 
 function getHttpStatus(error: unknown): number | undefined {
@@ -71,7 +71,7 @@ function getHttpStatus(error: unknown): number | undefined {
  * Anything other than a successful load with `success: true` hides the bar:
  * 403, 200 with `success: false`, network errors, 5xx, redirected requests.
  */
-function isQueryDenied(query: { isError: boolean, error: unknown, data: MasqueradeStatus | undefined }): boolean {
+function isQueryDenied(query: { isError: boolean; error: unknown; data: MasqueradeStatus | undefined }): boolean {
   if (query.isError) {
     return true;
   }
@@ -94,7 +94,7 @@ export function formatErrorMessage(
 }
 
 function pickErrorMessage(
-  mutation: { isError: boolean, error: unknown, data: MasqueradeStatus | undefined },
+  mutation: { isError: boolean; error: unknown; data: MasqueradeStatus | undefined },
 ): MasqueradeErrorMessage | null {
   if (mutation.isError) {
     return getHttpStatus(mutation.error) === 404
@@ -108,18 +108,18 @@ function pickErrorMessage(
 }
 
 export interface MasqueradeState {
-  active: ActiveMasqueradeData,
-  available: MasqueradeOption[],
-  pendingOption: MasqueradeOption | null,
-  showUserNameInput: boolean,
-  userName: string,
-  setUserName: (value: string) => void,
-  select: (option: MasqueradeOption) => void,
-  submitUserName: () => void,
-  errorMessage: MasqueradeErrorMessage | null,
-  isSubmitting: boolean,
-  isLoading: boolean,
-  isDenied: boolean,
+  active: ActiveMasqueradeData;
+  available: MasqueradeOption[];
+  pendingOption: MasqueradeOption | null;
+  showUserNameInput: boolean;
+  userName: string;
+  setUserName: (value: string) => void;
+  select: (option: MasqueradeOption) => void;
+  submitUserName: () => void;
+  errorMessage: MasqueradeErrorMessage | null;
+  isSubmitting: boolean;
+  isLoading: boolean;
+  isDenied: boolean;
 }
 
 export function useMasqueradeState(courseId: string): MasqueradeState {

--- a/shell/header/course-bar/masquerade/masquerade-widget/MasqueradeUserNameInput.tsx
+++ b/shell/header/course-bar/masquerade/masquerade-widget/MasqueradeUserNameInput.tsx
@@ -8,9 +8,9 @@ import { useMasqueradeContext } from '../MasqueradeContext';
 import messages from './messages';
 
 interface Props {
-  id?: string,
-  className?: string,
-  autoFocus?: boolean,
+  id?: string;
+  className?: string;
+  autoFocus?: boolean;
 }
 
 export function MasqueradeUserNameInput({ id, className, autoFocus }: Props) {

--- a/shell/header/course-bar/masquerade/masquerade-widget/MasqueradeWidgetOption.tsx
+++ b/shell/header/course-bar/masquerade/masquerade-widget/MasqueradeWidgetOption.tsx
@@ -5,7 +5,7 @@ import { isOptionSelected } from '../hooks';
 import type { MasqueradeOption } from '../data/api';
 
 interface Props {
-  option: MasqueradeOption,
+  option: MasqueradeOption;
 }
 
 export function MasqueradeWidgetOption({ option }: Props) {

--- a/shell/header/course-bar/navigation/CourseTabsNavigation.tsx
+++ b/shell/header/course-bar/navigation/CourseTabsNavigation.tsx
@@ -14,8 +14,8 @@ import { isClientRoute } from '../utils';
 import './course-tabs-navigation.scss';
 
 interface ResolvedTab extends CourseTab {
-  pathname: string,
-  clientPath: string | null,
+  pathname: string;
+  clientPath: string | null;
 }
 
 const CourseTabsNavigation = () => {

--- a/shell/header/course-bar/utils.test.ts
+++ b/shell/header/course-bar/utils.test.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
 });
 
 /* Stub `getProvidesAsStrings` to return per-key role lists. */
-function provideRoles(byKey: { courseBar?: string[], masquerade?: string[] }) {
+function provideRoles(byKey: { courseBar?: string[]; masquerade?: string[] }) {
   mockGetProvidesAsStrings.mockImplementation(id => {
     if (id === providesCourseBarRolesId) {
       return byKey.courseBar ?? [];

--- a/shell/header/helpButtonSlotOperation.tsx
+++ b/shell/header/helpButtonSlotOperation.tsx
@@ -4,7 +4,7 @@ import HelpButton from './HelpButton';
 export const helpWidgetId = 'org.openedx.frontend.widget.header.help.v1';
 
 export function helpButtonSlotOperation(
-  { appId, role }: { appId: string, role: string },
+  { appId, role }: { appId: string; role: string },
 ): WidgetAppendOperation {
   return {
     slotId: 'org.openedx.frontend.slot.header.secondaryLinks.v1',

--- a/shell/menus/LinkMenuItem.tsx
+++ b/shell/menus/LinkMenuItem.tsx
@@ -11,10 +11,10 @@ import {
 } from './data/utils';
 
 interface LinkMenuItemProps {
-  label: MenuItemName,
-  role?: string,
-  url?: string,
-  variant?: 'hyperlink' | 'navLink' | 'navDropdownItem' | 'dropdownItem',
+  label: MenuItemName;
+  role?: string;
+  url?: string;
+  variant?: 'hyperlink' | 'navLink' | 'navDropdownItem' | 'dropdownItem';
 }
 
 export default function LinkMenuItem({ label, role, url, variant = 'hyperlink' }: LinkMenuItemProps) {

--- a/shell/menus/NavDropdownMenuSlot.tsx
+++ b/shell/menus/NavDropdownMenuSlot.tsx
@@ -10,8 +10,8 @@ import {
 } from './data/utils';
 
 interface DropdownMenuSlotProps {
-  id: string,
-  label: MenuItemName,
+  id: string;
+  label: MenuItemName;
 }
 
 export default function DropdownMenuSlot({ id, label }: DropdownMenuSlotProps) {

--- a/shell/menus/ProfileLinkMenuItem.tsx
+++ b/shell/menus/ProfileLinkMenuItem.tsx
@@ -5,9 +5,9 @@ import { MenuItemName } from '../../types';
 import LinkMenuItem from './LinkMenuItem';
 
 interface ProfileLinkMenuItemProps {
-  label: MenuItemName,
-  role: string,
-  variant?: 'hyperlink' | 'navLink' | 'navDropdownItem' | 'dropdownItem',
+  label: MenuItemName;
+  role: string;
+  variant?: 'hyperlink' | 'navLink' | 'navDropdownItem' | 'dropdownItem';
 }
 
 export default function ProfileLinkMenuItem({ label, role, variant = 'hyperlink' }: ProfileLinkMenuItemProps) {

--- a/test-site/src/example-page/Image.tsx
+++ b/test-site/src/example-page/Image.tsx
@@ -1,9 +1,9 @@
 import { CSSProperties } from 'react';
 
 interface ImageProps {
-  src: string,
-  alt?: string,
-  style?: CSSProperties,
+  src: string;
+  alt?: string;
+  style?: CSSProperties;
 }
 
 const Image = ({ alt, ...rest }: ImageProps) => <img alt={alt} {...rest} />;

--- a/tools/cli/utils/formatter.ts
+++ b/tools/cli/utils/formatter.ts
@@ -1,3 +1,3 @@
-exports.format = (messages: Record<string, { defaultMessage: string, description: string }>) => Object.fromEntries(
+exports.format = (messages: Record<string, { defaultMessage: string; description: string }>) => Object.fromEntries(
   Object.entries(messages).map(([id, { defaultMessage }]) => [id, defaultMessage]),
 );

--- a/tools/cli/utils/translations/messagesObject.ts
+++ b/tools/cli/utils/translations/messagesObject.ts
@@ -2,18 +2,18 @@ import fs from 'fs';
 import path from 'path';
 
 export interface LocaleImport {
-  localeName: string, // e.g. 'es_419'
-  filename: string, // e.g. 'es_419.json'
+  localeName: string; // e.g. 'es_419'
+  filename: string; // e.g. 'es_419.json'
 }
 
 export interface LocaleEntry {
-  key: string, // e.g. 'es-419'
-  varName: string, // e.g. 'es_419'
+  key: string; // e.g. 'es-419'
+  varName: string; // e.g. 'es_419'
 }
 
 export interface MessagesObject {
-  imports: LocaleImport[],
-  entries: LocaleEntry[],
+  imports: LocaleImport[];
+  entries: LocaleEntry[];
 }
 
 /**

--- a/tools/cli/utils/translations/pull.test.ts
+++ b/tools/cli/utils/translations/pull.test.ts
@@ -7,8 +7,8 @@ import { pull } from './pull';
 jest.mock('./prepare');
 
 interface AtlasTranslations {
-  path?: string,
-  dependencies?: string[],
+  path?: string;
+  dependencies?: string[];
 }
 
 function createPackage(baseDir: string, name: string, atlasTranslations?: AtlasTranslations): void {

--- a/tools/cli/utils/translations/pull.ts
+++ b/tools/cli/utils/translations/pull.ts
@@ -3,16 +3,16 @@ import path from 'path';
 import { prepare } from './prepare';
 
 interface PackageTranslationsConfig {
-  name?: string,
+  name?: string;
   atlasTranslations?: {
-    path?: string,
-    dependencies?: string[],
-  },
+    path?: string;
+    dependencies?: string[];
+  };
 }
 
 interface ResolvedMapping {
-  from: string, // atlas FROM path
-  to: string, // full package name (TO)
+  from: string; // atlas FROM path
+  to: string; // full package name (TO)
 }
 
 function validateSiteTranslationsConfig(siteRoot: string): void {
@@ -40,8 +40,8 @@ function validateSiteTranslationsConfig(siteRoot: string): void {
 }
 
 function readTranslationsConfig(pkgJsonPath: string, nodeModulesBase: string): {
-  packageName: string,
-  config: PackageTranslationsConfig,
+  packageName: string;
+  config: PackageTranslationsConfig;
 } | null {
   const packageName = path.relative(nodeModulesBase, path.dirname(pkgJsonPath));
 
@@ -121,10 +121,10 @@ export function pull({
   shouldPrepare,
   atlasOptions = '',
 }: {
-  siteRoot: string,
-  execFileSync: (file: string, args: string[]) => void,
-  shouldPrepare: boolean,
-  atlasOptions?: string,
+  siteRoot: string;
+  execFileSync: (file: string, args: string[]) => void;
+  shouldPrepare: boolean;
+  atlasOptions?: string;
 }): void {
   validateSiteTranslationsConfig(siteRoot);
 

--- a/tools/eslint/base.eslint.config.js
+++ b/tools/eslint/base.eslint.config.js
@@ -102,11 +102,11 @@ module.exports = tseslint.config(
       '@stylistic/brace-style': ['error', '1tbs'],
       '@stylistic/member-delimiter-style': ['error', {
         multiline: {
-          delimiter: 'comma',
+          delimiter: 'semi',
           requireLast: true,
         },
         singleline: {
-          delimiter: 'comma',
+          delimiter: 'semi',
           requireLast: false,
         }
       }],

--- a/types.ts
+++ b/types.ts
@@ -6,8 +6,8 @@ import { SlotOperation } from './runtime/slots/types';
 // Apps
 
 export interface ExternalRoute {
-  role: string,
-  url: string,
+  role: string;
+  url: string;
 }
 
 export type RoleRouteObject = RouteObject & {
@@ -15,8 +15,8 @@ export type RoleRouteObject = RouteObject & {
     /**
      * Route roles identify the purpose(s) a route fulfills in the site.
      */
-    roles?: string[],
-  },
+    roles?: string[];
+  };
 };
 
 export type AppConfig = Record<string, unknown>;
@@ -24,19 +24,19 @@ export type AppConfig = Record<string, unknown>;
 export type AppProvider = FC<{ children?: ReactNode }>;
 
 export interface App {
-  appId: string,
-  routes?: RoleRouteObject[],
-  providers?: AppProvider[],
-  slots?: SlotOperation[],
-  externalScripts?: ExternalScriptLoaderClass[],
-  config?: AppConfig,
-  provides?: Record<string, unknown>,
+  appId: string;
+  routes?: RoleRouteObject[];
+  providers?: AppProvider[];
+  slots?: SlotOperation[];
+  externalScripts?: ExternalScriptLoaderClass[];
+  config?: AppConfig;
+  provides?: Record<string, unknown>;
 }
 
 // External Scripts
 
 export interface ExternalScriptLoader {
-  loadScript(): void,
+  loadScript(): void;
 }
 
 export type ExternalScriptLoaderClass = new (data: { config: AppConfig }) => ExternalScriptLoader;
@@ -44,16 +44,16 @@ export type ExternalScriptLoaderClass = new (data: { config: AppConfig }) => Ext
 // Site Config
 
 export interface RequiredSiteConfig {
-  siteId: string,
-  siteName: string,
-  baseUrl: string,
+  siteId: string;
+  siteName: string;
+  baseUrl: string;
 
   // Backends
-  lmsBaseUrl: string,
+  lmsBaseUrl: string;
 
   // Frontends
-  loginUrl: string,
-  logoutUrl: string,
+  loginUrl: string;
+  logoutUrl: string;
 }
 
 export type LocalizedMessages = Record<string, Record<string, string>>;
@@ -61,66 +61,66 @@ export type SiteMessages = LocalizedMessages[];
 
 export interface OptionalSiteConfig {
   // Site environment
-  environment: EnvironmentTypes,
+  environment: EnvironmentTypes;
 
   // Backends
-  cmsBaseUrl: string,
+  cmsBaseUrl: string;
 
   // Apps, routes, and URLs
-  apps: App[],
-  basename: string,
-  externalRoutes: ExternalRoute[],
-  externalLinkUrlOverrides: string[],
-  runtimeConfigJsonUrl: string | null,
-  commonAppConfig: AppConfig,
-  headerLogoImageUrl: string,
+  apps: App[];
+  basename: string;
+  externalRoutes: ExternalRoute[];
+  externalLinkUrlOverrides: string[];
+  runtimeConfigJsonUrl: string | null;
+  commonAppConfig: AppConfig;
+  headerLogoImageUrl: string;
 
   // Theme
-  theme: Theme,
+  theme: Theme;
 
   // Cookies
-  accessTokenCookieName: string,
-  languagePreferenceCookieName: string,
-  userInfoCookieName: string,
+  accessTokenCookieName: string;
+  languagePreferenceCookieName: string;
+  userInfoCookieName: string;
 
   // Paths
-  csrfTokenApiPath: string,
-  refreshAccessTokenApiPath: string,
+  csrfTokenApiPath: string;
+  refreshAccessTokenApiPath: string;
 
   // Logging
-  ignoredErrorRegex: RegExp | null,
+  ignoredErrorRegex: RegExp | null;
 
   // Analytics
-  segmentKey: string | null,
+  segmentKey: string | null;
 }
 
 export type SiteConfig = RequiredSiteConfig & Partial<OptionalSiteConfig>;
 
 export interface ThemeVariant {
-  url: string,
+  url: string;
 }
 
 export interface ThemeDefaults {
-  light?: string,
-  dark?: string,
+  light?: string;
+  dark?: string;
 }
 
 export type ThemeVariants = Record<string, ThemeVariant>;
 
 export interface Theme {
-  core?: ThemeVariant,
-  defaults?: ThemeDefaults,
-  variants?: ThemeVariants,
+  core?: ThemeVariant;
+  defaults?: ThemeDefaults;
+  variants?: ThemeVariants;
 }
 
 export interface User {
-  administrator: boolean,
-  email: string,
-  name: string,
-  roles: string[],
-  userId: number,
-  username: string,
-  avatar: string,
+  administrator: boolean;
+  email: string;
+  name: string;
+  roles: string[];
+  userId: number;
+  username: string;
+  avatar: string;
 }
 
 export enum EnvironmentTypes {


### PR DESCRIPTION
### Description

Switches the shared ESLint config to require semicolons rather than commas as TypeScript member delimiters, and auto-fixes the repository and test site to match.

This is a breaking change for consumers: the rule is inherited from frontend-base, so lint will fail after upgrading until `npm run lint:fix` is run.

Closes #296

### LLM usage notice

Built with assistance from Claude.
